### PR TITLE
Add more RPM fields, rename `section` -> `group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Dependencies now use the TOML syntax instead of a custom one [#39](https://github.com/wojciechkepka/pkger/pull/39)
 - Commands in configure, build and install scripts now use TOML syntax [#40](https://github.com/wojciechkepka/pkger/pull/40)
 - Add `--trace` option that sets log level of pkger to trace and make `--debug` actually set debug
+- Add some more fields for RPM builds, rename `section` to `group` and use it for RPM as well as DEB [#41](https://github.com/wojciechkepka/pkger/pull/41)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ maintainer = "Wojciech Kępka <wojciech@wkepka.dev>" # defaults to `none` for DE
 arch = "x86_64" # defaults to `noarch` on RPM and `all` on DEB, `x86_64` automatically converted to `amd64` on DEB...
 skip_default_deps = true # skip installing default dependencies, it might break the builds
 exclude = ["share", "info"] # directories to exclude from final package
+group = "" # acts as Group in RPM or Section in DEB build
 
 # Can be either a plain array when every image shares the dependencies:
 # build depends = [ "curl", "gcc", "pkg-config" ]
@@ -62,13 +63,22 @@ conflicts = []
 provides = []
 
 #### optional DEB fields
-section = ""
 priority = ""
 
 #### RPM fields
-release = "1" # defaults to 0
 obsoletes = [] # acts the same as `build_depends`
+release = "1" # defaults to 0
+epoch = "42"
+vendor = ""
+icon = ""
 summary = "shorter description" # if not provided defaults to value of `description`
+config_noreplace = "%{_sysconfdir}/%{name}/%{name}.conf"
+
+pre_script = ""
+post_script = ""
+preun_script = ""
+postun_script = ""
+
 ```
  - ### configure (Optional)
  - Optional configuration steps. If provided the steps will be executed before the build phase.

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,21 +332,33 @@ impl Pkger {
             description: opts.description.unwrap_or_else(|| "missing".to_string()),
             license: opts.license.unwrap_or_else(|| "missing".to_string()),
             images: vec![],
+
             maintainer: opts.maintainer,
             arch: opts.arch,
             source: opts.source,
             git,
             skip_default_deps: opts.skip_default_deps,
             exclude: opts.exclude,
+            group: opts.group,
+
             build_depends: vec_as_deps!(opts.build_depends),
             depends: vec_as_deps!(opts.depends),
             conflicts: vec_as_deps!(opts.conflicts),
             provides: vec_as_deps!(opts.provides),
-            section: opts.section,
+
             priority: opts.priority,
+
             release: opts.release,
             obsoletes: vec_as_deps!(opts.obsoletes),
+            epoch: opts.epoch,
+            vendor: opts.vendor,
+            icon: opts.icon,
             summary: opts.summary,
+            pre_script: None,
+            post_script: None,
+            preun_script: None,
+            postun_script: None,
+            config_noreplace: opts.config_noreplace,
         };
 
         let recipe = RecipeRep {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -95,6 +95,9 @@ pub struct GenRecipeOpts {
     #[clap(long)]
     /// Directories to exclude when creating the package
     pub exclude: Option<Vec<String>>,
+    #[clap(long)]
+    /// Group in RPM or section in DEB build
+    pub group: Option<String>,
 
     #[clap(long)]
     pub build_depends: Option<Vec<String>>,
@@ -114,9 +117,6 @@ pub struct GenRecipeOpts {
     // Only DEB
     #[clap(long)]
     /// Only applies to DEB build
-    pub section: Option<String>,
-    #[clap(long)]
-    /// Only applies to DEB build
     pub priority: Option<String>,
 
     // Only RPM
@@ -128,5 +128,17 @@ pub struct GenRecipeOpts {
     pub obsoletes: Option<Vec<String>>,
     #[clap(long)]
     /// Only applies to RPM
+    pub epoch: Option<String>,
+    #[clap(long)]
+    /// Only applies to RPM
+    pub vendor: Option<String>,
+    #[clap(long)]
+    /// Only applies to RPM
+    pub icon: Option<String>,
+    #[clap(long)]
+    /// Only applies to RPM
     pub summary: Option<String>,
+    #[clap(long)]
+    /// Only applies to RPM
+    pub config_noreplace: Option<String>,
 }

--- a/src/recipe/metadata.rs
+++ b/src/recipe/metadata.rs
@@ -12,6 +12,50 @@ use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
+#[derive(Clone, Deserialize, Serialize, Debug)]
+pub struct MetadataRep {
+    // Required
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub license: String,
+    pub images: Vec<toml::Value>,
+
+    // Common optional
+    pub maintainer: Option<String>,
+    pub arch: Option<String>,
+    /// http/https or file system source pointing to a tar.gz or tar.xz package
+    pub source: Option<String>,
+    /// Git repository as source
+    pub git: Option<toml::Value>,
+    /// Whether to install default dependencies before build
+    pub skip_default_deps: Option<bool>,
+    /// Directories to exclude when creating the package
+    pub exclude: Option<Vec<String>>,
+    pub group: Option<String>,
+
+    pub build_depends: Option<toml::Value>,
+    pub depends: Option<toml::Value>,
+    pub conflicts: Option<toml::Value>,
+    pub provides: Option<toml::Value>,
+
+    // Only DEB
+    pub priority: Option<String>,
+
+    // Only RPM
+    pub obsoletes: Option<toml::Value>,
+    pub release: Option<String>,
+    pub epoch: Option<String>,
+    pub vendor: Option<String>,
+    pub icon: Option<String>,
+    pub summary: Option<String>,
+    pub pre_script: Option<String>,
+    pub post_script: Option<String>,
+    pub preun_script: Option<String>,
+    pub postun_script: Option<String>,
+    pub config_noreplace: Option<String>,
+}
+
 #[derive(Clone, Debug)]
 pub struct Metadata {
     // General
@@ -31,6 +75,8 @@ pub struct Metadata {
     pub skip_default_deps: Option<bool>,
     /// Directories to exclude when creating the package
     pub exclude: Option<Vec<String>>,
+    /// Works as section in DEB and group in RPM
+    pub group: Option<String>,
 
     pub build_depends: Option<Dependencies>,
 
@@ -39,13 +85,20 @@ pub struct Metadata {
     pub provides: Option<Dependencies>,
 
     // Only DEB
-    pub section: Option<String>,
     pub priority: Option<String>,
 
     // Only RPM
-    pub release: Option<String>,
     pub obsoletes: Option<Dependencies>,
+    pub release: Option<String>,
+    pub epoch: Option<String>,
+    pub vendor: Option<String>,
+    pub icon: Option<String>,
     pub summary: Option<String>,
+    pub pre_script: Option<String>,
+    pub post_script: Option<String>,
+    pub preun_script: Option<String>,
+    pub postun_script: Option<String>,
+    pub config_noreplace: Option<String>,
 }
 
 impl Metadata {
@@ -113,12 +166,13 @@ impl TryFrom<MetadataRep> for Metadata {
         Ok(Self {
             name: rep.name,
             version: rep.version,
-            arch: rep.arch,
-            release: rep.release,
             description: rep.description,
             license: rep.license,
-            source: rep.source,
             images,
+
+            maintainer: rep.maintainer,
+            arch: rep.arch,
+            source: rep.source,
             git: {
                 if let Some(val) = rep.git {
                     GitSource::try_from(val).map(Some)?
@@ -126,53 +180,31 @@ impl TryFrom<MetadataRep> for Metadata {
                     None
                 }
             },
-            depends,
             skip_default_deps: rep.skip_default_deps,
+            exclude: rep.exclude,
+            group: rep.group,
+
             build_depends,
-            obsoletes,
+
+            depends,
             conflicts,
             provides,
-            exclude: rep.exclude,
-            maintainer: rep.maintainer,
-            section: rep.section,
+
+            // only DEB
             priority: rep.priority,
+
+            // only RPM
+            obsoletes,
+            release: rep.release,
+            epoch: rep.epoch,
+            vendor: rep.vendor,
+            icon: rep.icon,
             summary: rep.summary,
+            pre_script: rep.pre_script,
+            post_script: rep.post_script,
+            preun_script: rep.preun_script,
+            postun_script: rep.postun_script,
+            config_noreplace: rep.config_noreplace,
         })
     }
-}
-
-#[derive(Clone, Deserialize, Serialize, Debug)]
-pub struct MetadataRep {
-    // Required
-    pub name: String,
-    pub version: String,
-    pub description: String,
-    pub license: String,
-    pub images: Vec<toml::Value>,
-
-    // Common optional
-    pub maintainer: Option<String>,
-    pub arch: Option<String>,
-    /// http/https or file system source pointing to a tar.gz or tar.xz package
-    pub source: Option<String>,
-    /// Git repository as source
-    pub git: Option<toml::Value>,
-    /// Whether to install default dependencies before build
-    pub skip_default_deps: Option<bool>,
-    /// Directories to exclude when creating the package
-    pub exclude: Option<Vec<String>>,
-
-    pub build_depends: Option<toml::Value>,
-    pub depends: Option<toml::Value>,
-    pub conflicts: Option<toml::Value>,
-    pub provides: Option<toml::Value>,
-
-    // Only DEB
-    pub section: Option<String>,
-    pub priority: Option<String>,
-
-    // Only RPM
-    pub release: Option<String>,
-    pub obsoletes: Option<toml::Value>,
-    pub summary: Option<String>,
 }

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -138,6 +138,10 @@ impl Recipe {
             builder = builder.add_provides_entries(provides.resolve_names(image));
         }
 
+        if let Some(group) = &self.metadata.group {
+            builder = builder.section(group);
+        }
+
         builder.build()
     }
 
@@ -182,10 +186,36 @@ impl Recipe {
             .add_sources_entries(sources)
             .install_script(&install_script)
             .description(&self.metadata.description);
+        if let Some(group) = &self.metadata.group {
+            builder = builder.group(group);
+        }
         if let Some(maintainer) = &self.metadata.maintainer {
             builder = builder.packager(maintainer);
         }
-
+        if let Some(epoch) = &self.metadata.epoch {
+            builder = builder.epoch(epoch);
+        }
+        if let Some(vendor) = &self.metadata.vendor {
+            builder = builder.vendor(vendor);
+        }
+        if let Some(icon) = &self.metadata.icon {
+            builder = builder.icon(icon);
+        }
+        if let Some(pre_script) = &self.metadata.pre_script {
+            builder = builder.pre_script(pre_script);
+        }
+        if let Some(post_script) = &self.metadata.post_script {
+            builder = builder.post_script(post_script);
+        }
+        if let Some(preun_script) = &self.metadata.preun_script {
+            builder = builder.preun_script(preun_script);
+        }
+        if let Some(post_script) = &self.metadata.post_script {
+            builder = builder.post_script(post_script);
+        }
+        if let Some(config_noreplace) = &self.metadata.config_noreplace {
+            builder = builder.config_noreplace(config_noreplace);
+        }
         if let Some(conflicts) = &self.metadata.conflicts {
             builder = builder.add_conflicts_entries(conflicts.resolve_names(image));
         }


### PR DESCRIPTION
This PR adds some missing fields that RPM provides and renames `section` field of `metadata` to `group`. It will be used as group in RPM build as well as section in DEB build.