### PR TITLE
Separate rpm and deb sections in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Commands in configure, build and install scripts now use TOML syntax [#40](https://github.com/wojciechkepka/pkger/pull/40)
 - Add `--trace` option that sets log level of pkger to trace and make `--debug` actually set debug
 - Add some more fields for RPM builds, rename `section` to `group` and use it for RPM as well as DEB [#41](https://github.com/wojciechkepka/pkger/pull/41)
+- Separate RPM and DEB fields in recipe metadata [#42](https://github.com/wojciechkepka/pkger/pull/42)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The recipe is divided into 2 required (*metadata*, *build*) and 3 optional (*con
    - If `git` is provided as a field, the repository that it points to will be automatically extracted to `$PKGER_OUT_DIR`, otherwise `pkger` will try to fetch `source`.
    - If `source` starts with a prefix like `http` or `https` the file that if points to will be downloaded. If the file is an archive like `.tar.gz` or `.tar.xz` it will be directly extracted to `$PKGER_BLD_DIR`, otherwise the file will be copied to the directory untouched.
 ```toml
-[metadata]
 #### required common fields
+
+[metadata]
 name = "pkger"
 version = "0.1.0"
 description = "A package building tool utilizing Docker"
@@ -36,37 +37,49 @@ images = [
 
 
 #### optional common
+
 source = "" # remote source or file system location
 
 git = "https://github.com/wojciechkepka/pkger.git" # will default to branch = "master"
 # or specify a branch like this:
 # git = { url = "https://github.com/wojciechkepka/pkger.git", branch = "dev" }
 
-maintainer = "Wojciech Kępka <wojciech@wkepka.dev>" # defaults to `none` for DEB build as it's required
+maintainer = "Wojciech Kępka <wojciech@wkepka.dev>"
+
 arch = "x86_64" # defaults to `noarch` on RPM and `all` on DEB, `x86_64` automatically converted to `amd64` on DEB...
+
 skip_default_deps = true # skip installing default dependencies, it might break the builds
+
 exclude = ["share", "info"] # directories to exclude from final package
+
 group = "" # acts as Group in RPM or Section in DEB build
 
-# Can be either a plain array when every image shares the dependencies:
-# build depends = [ "curl", "gcc", "pkg-config" ]
-#
+#### dependencies
+
+# This fields can be specified as arrays
+depends   = []
+conflicts = []
+provides  = []
+
 # Or specified per image as a map:
 [metadata.build_depends]
-all = ["gcc", "pkg-config", "git"]
-centos8 = ["cargo", "openssl-devel"]
+all      = ["gcc", "pkg-config", "git"]
+centos8  = ["cargo", "openssl-devel"]
 debian10 = ["curl", "libssl-dev"]
 
-# Same applies to this fields
-depends = []
-conflicts = []
-provides = []
+# If specifying some deps as array and some as maps the arrays always have to come before the maps
+# otherwise TOML breaks
 
-#### optional DEB fields
+
+#### DEB fields
+
+[metadata.deb]
 priority = ""
 
+
 #### RPM fields
-obsoletes = [] # acts the same as `build_depends`
+
+[metadata.rpm]
 release = "1" # defaults to 0
 epoch = "42"
 vendor = ""
@@ -78,6 +91,12 @@ pre_script = ""
 post_script = ""
 preun_script = ""
 postun_script = ""
+
+# acts the same as other dependencies - can be passed as array
+# obsoletes = ["foo"]
+# or as a map per image at the end of rpm fields definition
+[metadata.rpm.obsoletes]
+centos8 = ["foo"]
 
 ```
  - ### configure (Optional)

--- a/src/job/build/rpm.rs
+++ b/src/job/build/rpm.rs
@@ -20,11 +20,7 @@ impl<'job> BuildContainerCtx<'job> {
             &self.recipe.metadata.version,
         ]
         .join("");
-        let release = if let Some(release) = &self.recipe.metadata.release {
-            release
-        } else {
-            "0"
-        };
+        let release = self.recipe.metadata.rpm_release();
         let arch = self.recipe.metadata.rpm_arch();
         let buildroot_name = [&name, "-", &release, ".", &arch].join("");
         let source_tar = [&name, ".tar.gz"].join("");

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use crate::opts::{BuildOpts, GenRecipeOpts, PkgerCmd, PkgerOpts};
 use crate::recipe::Recipes;
 
 pub use anyhow::{Error, Result};
-use recipe::{MetadataRep, RecipeRep};
+use recipe::{DebRep, MetadataRep, RecipeRep, RpmRep};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
@@ -326,6 +326,24 @@ impl Pkger {
             }};
         }
 
+        let deb = DebRep {
+            priority: opts.priority,
+        };
+
+        let rpm = RpmRep {
+            release: opts.release,
+            obsoletes: vec_as_deps!(opts.obsoletes),
+            epoch: opts.epoch,
+            vendor: opts.vendor,
+            icon: opts.icon,
+            summary: opts.summary,
+            pre_script: None,
+            post_script: None,
+            preun_script: None,
+            postun_script: None,
+            config_noreplace: opts.config_noreplace,
+        };
+
         let metadata = MetadataRep {
             name: opts.name,
             version: opts.version.unwrap_or_else(|| "1.0.0".to_string()),
@@ -346,19 +364,8 @@ impl Pkger {
             conflicts: vec_as_deps!(opts.conflicts),
             provides: vec_as_deps!(opts.provides),
 
-            priority: opts.priority,
-
-            release: opts.release,
-            obsoletes: vec_as_deps!(opts.obsoletes),
-            epoch: opts.epoch,
-            vendor: opts.vendor,
-            icon: opts.icon,
-            summary: opts.summary,
-            pre_script: None,
-            post_script: None,
-            preun_script: None,
-            postun_script: None,
-            config_noreplace: opts.config_noreplace,
+            deb: Some(deb),
+            rpm: Some(rpm),
         };
 
         let recipe = RecipeRep {

--- a/src/recipe/mod.rs
+++ b/src/recipe/mod.rs
@@ -119,15 +119,9 @@ impl TryFrom<RecipeRep> for Recipe {
 impl Recipe {
     pub fn as_deb_control(&self, image: &str) -> BinaryDebControl {
         let arch = self.metadata.deb_arch();
-        let maintainer = if let Some(maintainer) = &self.metadata.maintainer {
-            maintainer
-        } else {
-            "none"
-        };
         let mut builder = DebControlBuilder::binary_package_builder(&self.metadata.name)
             .version(&self.metadata.version)
             .description(&self.metadata.description)
-            .maintainer(maintainer)
             .architecture(arch);
 
         if let Some(group) = &self.metadata.group {
@@ -141,6 +135,9 @@ impl Recipe {
         }
         if let Some(provides) = &self.metadata.provides {
             builder = builder.add_provides_entries(provides.resolve_names(image));
+        }
+        if let Some(maintainer) = &self.metadata.maintainer {
+            builder = builder.maintainer(maintainer);
         }
 
         if let Some(deb) = &self.metadata.deb {


### PR DESCRIPTION
This PR separates fields used by rpm and deb build in `Metadata`. It will now be clear which fields are responsible for each build.