### PR TITLE
Add some extra PKG metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Add missing fields for DEB builds, add `url` field to metadata [#43](https://github.com/wojciechkepka/pkger/pull/43)
 - Add initial PKG target [#44](https://github.com/wojciechkepka/pkger/pull/44)
 - Make `release` and `epoch` fields of metadata global rather than RPM specific
+- Add some missing extra fields in metadata for PKG [#45](https://github.com/wojciechkepka/pkger/pull/45)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Separate RPM and DEB fields in recipe metadata [#42](https://github.com/wojciechkepka/pkger/pull/42)
 - Add missing fields for DEB builds, add `url` field to metadata [#43](https://github.com/wojciechkepka/pkger/pull/43)
 - Add initial PKG target [#44](https://github.com/wojciechkepka/pkger/pull/44)
+- Make `release` and `epoch` fields of metadata global rather than RPM specific

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "deb-control"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d86227a865aa36daca58b040f115d3f47cb9fa452487484fa512025926c45d2"
+checksum = "60af0342ae805d703ffbc0028708d17c388175c4e6ffd65b357cb2258a7709ec"
 dependencies = [
  "paste",
  "pkgspec",

--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ centos8 = ["foo"]
 #### PKG fields
 
 [metadata.pkg]
+# location of the script in $PKGER_OUT_DIR that contains pre/post install/upgrade/remove functions
+# to be included in the final pkg
+install = ".install"
+
+# A list of files to be backed up when package will be removed or upgraded
+backup = ["/etc/pkger.conf"]
+
+# A list of packages that this package replaces
+replaces = []
+
+# This are dependencies that this package needs to offer full functionality.
+# Each dependency should contain a short description in this format:
+optdepends = [
+    "libpng: PNG images support",
+    "alsa-lib: sound support"
+]
 ```
  - ### configure (Optional)
  - Optional configuration steps. If provided the steps will be executed before the build phase.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pkger 📦
+
 [![Build Status](https://github.com/wojciechkepka/pkger/workflows/pkger%20CI/badge.svg)](https://github.com/wojciechkepka/pkger/actions?query=workflow%3A%22pkger+CI%22)
 
 **pkger** is a tool that automates building *RPMs*, *DEBs*, *PKG*, and other packages on multiple *Linux* distributions, versions and architectures with the help of Docker.
@@ -37,6 +38,9 @@ images = [
 
 
 #### optional common
+release = "1" # defaults to "0"
+
+epoch = "42"
 
 source = "" # remote source or file system location
 
@@ -93,8 +97,6 @@ enchances = []
 #### RPM fields
 
 [metadata.rpm]
-release = "1" # defaults to "0"
-epoch = "42"
 vendor = ""
 icon = ""
 summary = "shorter description" # if not provided defaults to value of `description`
@@ -114,8 +116,6 @@ centos8 = ["foo"]
 #### PKG fields
 
 [metadata.pkg]
-pkgrel = "2" # defaults to "0"
-
 ```
  - ### configure (Optional)
  - Optional configuration steps. If provided the steps will be executed before the build phase.

--- a/src/job/build/rpm.rs
+++ b/src/job/build/rpm.rs
@@ -20,7 +20,7 @@ impl<'job> BuildContainerCtx<'job> {
             &self.recipe.metadata.version,
         ]
         .join("");
-        let release = self.recipe.metadata.rpm_release();
+        let release = self.recipe.metadata.release();
         let arch = self.recipe.metadata.rpm_arch();
         let buildroot_name = [&name, "-", &release, ".", &arch].join("");
         let source_tar = [&name, ".tar.gz"].join("");

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,7 @@ impl Pkger {
             recommends: vec_as_deps!(opts.recommends),
             suggests: vec_as_deps!(opts.suggests),
             breaks: vec_as_deps!(opts.breaks),
-            replaces: vec_as_deps!(opts.replaces),
+            replaces: vec_as_deps!(opts.replaces.clone()),
             enchances: vec_as_deps!(opts.enchances),
         };
 
@@ -352,7 +352,12 @@ impl Pkger {
             config_noreplace: opts.config_noreplace,
         };
 
-        let pkg = PkgRep {};
+        let pkg = PkgRep {
+            install: opts.install_script,
+            backup: opts.backup_files,
+            replaces: vec_as_deps!(opts.replaces),
+            optdepends: opts.optdepends,
+        };
 
         let metadata = MetadataRep {
             name: opts.name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,9 +341,7 @@ impl Pkger {
         };
 
         let rpm = RpmRep {
-            release: opts.release,
             obsoletes: vec_as_deps!(opts.obsoletes),
-            epoch: opts.epoch,
             vendor: opts.vendor,
             icon: opts.icon,
             summary: opts.summary,
@@ -354,9 +352,7 @@ impl Pkger {
             config_noreplace: opts.config_noreplace,
         };
 
-        let pkg = PkgRep {
-            pkgrel: opts.pkgrel,
-        };
+        let pkg = PkgRep {};
 
         let metadata = MetadataRep {
             name: opts.name,
@@ -373,6 +369,8 @@ impl Pkger {
             skip_default_deps: opts.skip_default_deps,
             exclude: opts.exclude,
             group: opts.group,
+            release: opts.release,
+            epoch: opts.epoch,
 
             build_depends: vec_as_deps!(opts.build_depends),
             depends: vec_as_deps!(opts.depends),

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -99,8 +99,15 @@ pub struct GenRecipeOpts {
     /// Directories to exclude when creating the package
     pub exclude: Option<Vec<String>>,
     #[clap(long)]
-    /// Group in RPM or section in DEB build
+    /// Group in RPM and PKG or section in DEB build
     pub group: Option<String>,
+    #[clap(long)]
+    /// The release number. This is usually a positive integer number that allows to differentiate
+    /// between consecutive builds of the same version of a package
+    pub release: Option<String>,
+    #[clap(long)]
+    /// Used to force the package to be seen as newer than any previous version with a lower epoch
+    pub epoch: Option<String>,
 
     #[clap(long)]
     pub build_depends: Option<Vec<String>>,
@@ -153,13 +160,7 @@ pub struct GenRecipeOpts {
     // Only RPM
     #[clap(long)]
     /// Only applies to RPM
-    pub release: Option<String>,
-    #[clap(long)]
-    /// Only applies to RPM
     pub obsoletes: Option<Vec<String>>,
-    #[clap(long)]
-    /// Only applies to RPM
-    pub epoch: Option<String>,
     #[clap(long)]
     /// Only applies to RPM
     pub vendor: Option<String>,
@@ -172,9 +173,4 @@ pub struct GenRecipeOpts {
     #[clap(long)]
     /// Only applies to RPM
     pub config_noreplace: Option<String>,
-
-    // Only PKG
-    #[clap(long)]
-    /// Only applies to PKG
-    pub pkgrel: Option<String>,
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -124,6 +124,10 @@ pub struct GenRecipeOpts {
     /// `HTTP_PROXY=proxy.corp.local,PATH=$PATH:/opt/dev/bin`
     pub env: Option<String>,
 
+    #[clap(long)]
+    /// A list of packages that this packages replaces. Applies to DEB and PKG
+    pub replaces: Option<Vec<String>>,
+
     // Only DEB
     #[clap(long)]
     /// Only applies to DEB build
@@ -152,9 +156,6 @@ pub struct GenRecipeOpts {
     pub breaks: Option<Vec<String>>,
     #[clap(long)]
     /// Only applies to DEB build
-    pub replaces: Option<Vec<String>>,
-    #[clap(long)]
-    /// Only applies to DEB build
     pub enchances: Option<Vec<String>>,
 
     // Only RPM
@@ -173,4 +174,16 @@ pub struct GenRecipeOpts {
     #[clap(long)]
     /// Only applies to RPM
     pub config_noreplace: Option<String>,
+
+    // Only PKG
+    #[clap(long)]
+    /// The name of the .install script to be included in the package. Only applies to PKG
+    pub install_script: Option<String>,
+    #[clap(long)]
+    /// A list of files that can contain user-made changes and should be preserved during upgrade
+    /// or removal of a package. Only applies to PKG
+    pub backup_files: Option<Vec<String>>,
+    #[clap(long)]
+    /// Optional dependencies needed for full functionality of the package. Only applies to PKG
+    pub optdepends: Option<Vec<String>>,
 }

--- a/src/recipe/metadata.rs
+++ b/src/recipe/metadata.rs
@@ -285,7 +285,7 @@ impl Metadata {
     /// Returns the release number of this package if one exists, otherwise returns "0"
     pub fn release(&self) -> &str {
         if let Some(release) = &self.release {
-            return release.as_str();
+            release.as_str()
         } else {
             "0"
         }

--- a/src/recipe/metadata.rs
+++ b/src/recipe/metadata.rs
@@ -67,16 +67,39 @@ pub struct MetadataRep {
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
-pub struct PkgRep {}
+pub struct PkgRep {
+    /// The name of the .install script to be included in the package
+    pub install: Option<String>,
+    /// A list of files that can contain user-made changes and should be preserved during upgrade
+    /// or removal of a package
+    pub backup: Option<Vec<String>>,
+    pub replaces: Option<toml::Value>,
+    /// Optional dependencies needed for full functionality of the package
+    pub optdepends: Option<Vec<String>>,
+}
 
 #[derive(Clone, Debug)]
-pub struct PkgInfo {}
+pub struct PkgInfo {
+    /// The name of the .install script to be included in the package
+    pub install: Option<String>,
+    /// A list of files that can contain user-made changes and should be preserved during upgrade
+    /// or removal of a package
+    pub backup: Option<Vec<String>>,
+    pub replaces: Option<Dependencies>,
+    /// Optional dependencies needed for full functionality of the package
+    pub optdepends: Option<Vec<String>>,
+}
 
 impl TryFrom<PkgRep> for PkgInfo {
     type Error = Error;
 
     fn try_from(rep: PkgRep) -> Result<Self> {
-        Ok(Self {})
+        Ok(Self {
+            install: rep.install,
+            backup: rep.backup,
+            replaces: let_some_deps!(rep.replaces),
+            optdepends: rep.optdepends,
+        })
     }
 }
 


### PR DESCRIPTION
This PR adds some extra PKG fields to metadata like: `install`, `backup`, `replaces` and `optdepends`. 