### PR TITLE
Add an option to forward ssh agent from the host to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Add an option to sign RPMs with a GPG key [#55](https://github.com/wojciechkepka/pkger/pull/55)
 - Add an option to sign DEBs with a GPG key [#56](https://github.com/wojciechkepka/pkger/pull/56)
 - Fix image caching
+- Add `forward_ssh_agent` configuration option to forward the SSH authentication socket from the host machine to 
+  the container. [#58](https://github.com/wojciechkepka/pkger/pull/58)
 
 # 0.3.0
 - Configure script now has a working directory set to `$PKGER_BLD_DIR`

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,6 +1,8 @@
 # Configuration
 
-By default **pkger** will look for the config file in the home directory of the user running the process in a file `.pkger.yml`. If there is no global configuration current directory will be scand for the same file. To specify the location of the config file use `--config` or `-c` parameter.
+By default **pkger** will look for the config file in the home directory of the user running the process in a file
+`.pkger.yml`. If there is no global configuration current directory will be scand for the same file. To specify the
+location of the config file use `--config` or `-c` parameter.
 
 The configuration file has a following structure:
 
@@ -12,9 +14,13 @@ output_dir: ""
 # optional
 images_dir: ""
 docker: "unix:///var/run/docker.sock"
+
+# this will make the ssh auth socket available to the container so that it can use private keys from the host.
+forward_ssh_agent: true
 ```
 
-The required fields when running a build are `recipes_dir` and `output_dir`. First tells **pkger** where to look for [recipes](./recipes.md) to build, the second is the directory where the final packages will end up.
+The required fields when running a build are `recipes_dir` and `output_dir`. First tells **pkger** where to look for
+[recipes](./recipes.md) to build, the second is the directory where the final packages will end up.
 
 When using [custom images](./images.md) their location can be specified with `images_dir`.
 

--- a/pkger-cli/src/app.rs
+++ b/pkger-cli/src/app.rs
@@ -287,7 +287,8 @@ impl Application {
                                 self.images_state.clone(),
                                 self.is_running.clone(),
                                 is_simple,
-                                self.gpg_key.clone()
+                                self.gpg_key.clone(),
+                                self.config.forward_ssh_agent,
                             ))
                             .run(),
                         ));

--- a/pkger-cli/src/config.rs
+++ b/pkger-cli/src/config.rs
@@ -12,6 +12,7 @@ pub struct Configuration {
     pub docker: Option<String>,
     pub gpg_key: Option<PathBuf>,
     pub gpg_name: Option<String>,
+    #[serde(default)]
     pub forward_ssh_agent: bool,
 }
 impl Configuration {

--- a/pkger-cli/src/config.rs
+++ b/pkger-cli/src/config.rs
@@ -12,6 +12,7 @@ pub struct Configuration {
     pub docker: Option<String>,
     pub gpg_key: Option<PathBuf>,
     pub gpg_name: Option<String>,
+    pub forward_ssh_agent: bool,
 }
 impl Configuration {
     pub fn load<P: AsRef<Path>>(val: P) -> Result<Self> {

--- a/pkger-core/src/build/mod.rs
+++ b/pkger-core/src/build/mod.rs
@@ -46,6 +46,7 @@ pub struct Context {
     is_running: Arc<AtomicBool>,
     simple: bool,
     gpg_key: Option<GpgKey>,
+    forward_ssh_agent: bool,
 }
 
 pub async fn run(ctx: &mut Context) -> Result<PathBuf> {
@@ -140,6 +141,7 @@ impl Context {
         is_running: Arc<AtomicBool>,
         simple: bool,
         gpg_key: Option<GpgKey>,
+        forward_ssh_agent: bool,
     ) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -176,6 +178,7 @@ impl Context {
             is_running,
             simple,
             gpg_key,
+            forward_ssh_agent,
         }
     }
 

--- a/pkger-core/src/lib.rs
+++ b/pkger-core/src/lib.rs
@@ -9,5 +9,6 @@ pub mod gpg;
 pub mod image;
 pub mod oneshot;
 pub mod recipe;
+pub mod ssh;
 
 pub use anyhow::{anyhow, Context as ErrContext, Error, Result};

--- a/pkger-core/src/ssh.rs
+++ b/pkger-core/src/ssh.rs
@@ -1,0 +1,23 @@
+use crate::{ErrContext, Error, Result};
+
+use std::env;
+use std::path::PathBuf;
+
+pub const SOCK_ENV: &str = "SSH_AUTH_SOCK";
+
+/// Returns the path to the SSH authentication socket depending on the operating system
+/// and checks if the socket exists.
+pub fn auth_sock() -> Result<String> {
+    #[cfg(target_os = "linux")]
+    let socket = env::var(SOCK_ENV).context("missing ssh auth socket environment variable")?;
+
+    #[cfg(target_os = "macos")]
+    let socket = "/run/host-services/ssh-auth.sock".to_owned();
+
+    let path = PathBuf::from(&socket);
+    if !path.exists() {
+        return Err(Error::msg("ssh auth socket does not exist"));
+    }
+
+    Ok(socket)
+}


### PR DESCRIPTION
This PR adds initial support for forwarding the SSH agent authentication socket available on the host machine to the container so that users don't have to manually add SSH keys to access private repositories during the build.

Closes: #57 