### PR TITLE
Add an option to disable SSH host key verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   the container. [#58](https://github.com/wojciechkepka/pkger/pull/58)
 - Add `--no-sign` command line argument to `build` command so that users can disable signing for the particular build
   even when the gpg signing is enabled in the configuration.
+- Move `forward_ssh_agent` option to `ssh` configuration and rename it to `forward_agent` [#60](https://github.com/wojciechkepka/pkger/pull/60)
+- Add `disable_key_verification` to `ssh` configuration [#60](https://github.com/wojciechkepka/pkger/pull/60)
 
 # 0.3.0
 - Configure script now has a working directory set to `$PKGER_BLD_DIR`

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -15,12 +15,12 @@ output_dir: ""
 images_dir: ""
 docker: "unix:///var/run/docker.sock"
 
-[ssh]
-# this will make the ssh auth socket available to the container so that it can use private keys from the host.
-forward_agent: true
+ssh:
+  # this will make the ssh auth socket available to the container so that it can use private keys from the host.
+  forward_agent: true
 
-# This will allow tools that use SSH to connect to hosts that are not present in the `authorized_keys`
-disable_key_verification: true
+  # This will allow tools that use SSH to connect to hosts that are not present in the `authorized_keys`
+  disable_key_verification: true
 ```
 
 The required fields when running a build are `recipes_dir` and `output_dir`. First tells **pkger** where to look for

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -15,8 +15,12 @@ output_dir: ""
 images_dir: ""
 docker: "unix:///var/run/docker.sock"
 
+[ssh]
 # this will make the ssh auth socket available to the container so that it can use private keys from the host.
-forward_ssh_agent: true
+forward_agent: true
+
+# This will allow tools that use SSH to connect to hosts that are not present in the `authorized_keys`
+disable_key_verification: true
 ```
 
 The required fields when running a build are `recipes_dir` and `output_dir`. First tells **pkger** where to look for

--- a/pkger-cli/src/app.rs
+++ b/pkger-cli/src/app.rs
@@ -292,7 +292,7 @@ impl Application {
                                 self.is_running.clone(),
                                 is_simple,
                                 self.gpg_key.clone(),
-                                self.config.forward_ssh_agent,
+                                self.config.ssh.clone(),
                             ))
                             .run(),
                         ));

--- a/pkger-cli/src/config.rs
+++ b/pkger-cli/src/config.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use pkger_core::ssh::SshConfig;
 
 use serde::Deserialize;
 use std::fs;
@@ -12,9 +13,9 @@ pub struct Configuration {
     pub docker: Option<String>,
     pub gpg_key: Option<PathBuf>,
     pub gpg_name: Option<String>,
-    #[serde(default)]
-    pub forward_ssh_agent: bool,
+    pub ssh: Option<SshConfig>,
 }
+
 impl Configuration {
     pub fn load<P: AsRef<Path>>(val: P) -> Result<Self> {
         Ok(serde_yaml::from_slice(&fs::read(val.as_ref())?)?)

--- a/pkger-core/src/build/mod.rs
+++ b/pkger-core/src/build/mod.rs
@@ -11,6 +11,7 @@ use crate::docker::Docker;
 use crate::gpg::GpgKey;
 use crate::image::{Image, ImageState, ImagesState};
 use crate::recipe::{ImageTarget, Patch, Patches, Recipe, RecipeTarget};
+use crate::ssh::SshConfig;
 use crate::{ErrContext, Error, Result};
 
 use async_rwlock::RwLock;
@@ -46,7 +47,7 @@ pub struct Context {
     is_running: Arc<AtomicBool>,
     simple: bool,
     gpg_key: Option<GpgKey>,
-    forward_ssh_agent: bool,
+    ssh: Option<SshConfig>,
 }
 
 pub async fn run(ctx: &mut Context) -> Result<PathBuf> {
@@ -141,7 +142,7 @@ impl Context {
         is_running: Arc<AtomicBool>,
         simple: bool,
         gpg_key: Option<GpgKey>,
-        forward_ssh_agent: bool,
+        ssh: Option<SshConfig>,
     ) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -178,7 +179,7 @@ impl Context {
             is_running,
             simple,
             gpg_key,
-            forward_ssh_agent,
+            ssh,
         }
     }
 

--- a/pkger-core/src/recipe/metadata/deps.rs
+++ b/pkger-core/src/recipe/metadata/deps.rs
@@ -117,6 +117,20 @@ impl Dependencies {
         deps
     }
 
+    /// Returns `true` if the `image` depends on `dependency`.
+    pub fn depends_on(&self, image: &str, dependency: &str) -> bool {
+        if let Some(common_deps) = self.inner.get(COMMON_DEPS_KEY) {
+            if common_deps.contains(dependency) {
+                return true;
+            }
+        }
+        if let Some(image_deps) = self.inner.get(image) {
+            return image_deps.contains(dependency);
+        }
+
+        false
+    }
+
     pub fn inner(&self) -> &DepsMap {
         &self.inner
     }

--- a/pkger-core/src/ssh.rs
+++ b/pkger-core/src/ssh.rs
@@ -1,10 +1,19 @@
 use crate::{Error, Result};
 
+use serde::Deserialize;
 use std::path::PathBuf;
 #[cfg(target_os = "linux")]
 use {crate::ErrContext, std::env};
 
 pub const SOCK_ENV: &str = "SSH_AUTH_SOCK";
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct SshConfig {
+    #[serde(default)]
+    pub forward_agent: bool,
+    #[serde(default)]
+    pub disable_key_verification: bool,
+}
 
 /// Returns the path to the SSH authentication socket depending on the operating system
 /// and checks if the socket exists.


### PR DESCRIPTION
This could be further improved by adding an option to upload `authorized_keys` file so that users can specify which hosts are valid.