### PR TITLE
Update `--quiet` flag behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.5.0
 - If at least one task fails to build **pkger** will now return with exit code 1 [#66](https://github.com/wojciechkepka/pkger/pull/66)
+- `--quiet` flag now suppresses only container output, normal info output is still available [#67](https://github.com/wojciechkepka/pkger/pull/67)
 
 # 0.4.0
 - Add an option to sign RPMs with a GPG key [#55](https://github.com/wojciechkepka/pkger/pull/55)

--- a/pkger-cli/src/app.rs
+++ b/pkger-cli/src/app.rs
@@ -110,7 +110,7 @@ impl Application {
                 let tasks = self
                     .process_build_opts(build_opts)
                     .context("processing build opts")?;
-                self.process_tasks(tasks).await?;
+                self.process_tasks(tasks, opts.quiet).await?;
                 self.save_images_state().await;
                 Ok(())
             }
@@ -262,7 +262,7 @@ impl Application {
         Ok(tasks)
     }
 
-    async fn process_tasks(&mut self, tasks: Vec<BuildTask>) -> Result<()> {
+    async fn process_tasks(&mut self, tasks: Vec<BuildTask>, quiet: bool) -> Result<()> {
         let span = info_span!("process-jobs");
         async move {
             let jobs = FuturesUnordered::new();
@@ -290,6 +290,7 @@ impl Application {
                                 is_simple,
                                 self.gpg_key.clone(),
                                 self.config.ssh.clone(),
+                                quiet
                             ))
                             .run(),
                         ));

--- a/pkger-cli/src/fmt.rs
+++ b/pkger-cli/src/fmt.rs
@@ -21,8 +21,6 @@ pub fn setup_tracing(opts: &Opts) {
 
     let filter = if let Some(filter) = env::var_os("RUST_LOG") {
         filter.to_string_lossy().to_string()
-    } else if opts.quiet {
-        "pkger=error".to_string()
     } else if opts.trace {
         "pkger=trace".to_string()
     } else if opts.debug {

--- a/pkger-cli/src/opts.rs
+++ b/pkger-cli/src/opts.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 )]
 pub struct Opts {
     #[clap(short, long)]
-    /// Surpress all output (except for errors).
+    /// Suppress all output from containers.
     pub quiet: bool,
     #[clap(short, long)]
     /// Enable debug output.

--- a/pkger-core/src/build/container.rs
+++ b/pkger-core/src/build/container.rs
@@ -78,7 +78,7 @@ pub async fn spawn<'ctx>(
 pub async fn checked_exec(ctx: &Context<'_>, opts: &ExecContainerOpts) -> Result<Output<String>> {
     let span = info_span!("checked-exec");
     async move {
-        let out = ctx.container.exec(opts).await?;
+        let out = ctx.container.exec(opts, ctx.build.quiet).await?;
         if out.exit_code != 0 {
             Err(Error::msg(format!(
                 "command failed with exit code {}\nError:\n{}",

--- a/pkger-core/src/build/mod.rs
+++ b/pkger-core/src/build/mod.rs
@@ -48,6 +48,7 @@ pub struct Context {
     simple: bool,
     gpg_key: Option<GpgKey>,
     ssh: Option<SshConfig>,
+    quiet: bool,
 }
 
 pub async fn run(ctx: &mut Context) -> Result<PathBuf> {
@@ -143,6 +144,7 @@ impl Context {
         simple: bool,
         gpg_key: Option<GpgKey>,
         ssh: Option<SshConfig>,
+        quiet: bool,
     ) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -180,6 +182,7 @@ impl Context {
             simple,
             gpg_key,
             ssh,
+            quiet,
         }
     }
 

--- a/pkger-core/src/build/package/deb.rs
+++ b/pkger-core/src/build/package/deb.rs
@@ -40,7 +40,11 @@ pub async fn build(
         debug!(control = %control);
 
         ctx.container
-            .upload_files(vec![("./control", control.as_bytes())], &deb_dir)
+            .upload_files(
+                vec![("./control", control.as_bytes())],
+                &deb_dir,
+                ctx.build.quiet,
+            )
             .await
             .context("failed to upload control file to container")?;
 

--- a/pkger-core/src/build/package/pkg.rs
+++ b/pkger-core/src/build/package/pkg.rs
@@ -92,6 +92,7 @@ pub(crate) async fn build(
             .upload_files(
                 vec![("PKGBUILD".to_string(), pkgbuild.as_bytes())],
                 &bld_dir,
+                ctx.build.quiet,
             )
             .await
             .context("failed to upload PKGBUILD to container")?;

--- a/pkger-core/src/build/package/rpm.rs
+++ b/pkger-core/src/build/package/rpm.rs
@@ -107,7 +107,11 @@ pub(crate) async fn build(
         debug!(spec_file = %spec_file, spec = %spec);
 
         ctx.container
-            .upload_files(vec![(["./", &spec_file].join(""), spec.as_bytes())], &specs)
+            .upload_files(
+                vec![(["./", &spec_file].join(""), spec.as_bytes())],
+                &specs,
+                ctx.build.quiet,
+            )
             .await
             .context("failed to upload spec file to container")?;
 
@@ -169,7 +173,8 @@ pub(crate) async fn sign_package(ctx: &Context<'_>, package: &Path) -> Result<()
         vec![
             ("./.rpmmacros", macros.as_bytes()),
         ],
-        "/root/"
+        "/root/",
+        ctx.build.quiet,
         ).await.context("failed to upload rpm macros")?;
 
 

--- a/pkger-core/src/build/package/sign.rs
+++ b/pkger-core/src/build/package/sign.rs
@@ -23,7 +23,11 @@ pub(crate) async fn upload_gpg_key(
         .context("failed reading the gpg key")?;
 
     ctx.container
-        .upload_files(vec![("./GPG-SIGN-KEY", key.as_slice())], &destination)
+        .upload_files(
+            vec![("./GPG-SIGN-KEY", key.as_slice())],
+            &destination,
+            ctx.build.quiet,
+        )
         .instrument(span)
         .await
         .map(|_| destination.join("GPG-SIGN-KEY"))


### PR DESCRIPTION
Now the `--quiet` flag will only suppress the output from containers so that informations like the stage at which the build is are easier to recognize.