### PR TITLE
Store image state in OS cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - If at least one task fails to build **pkger** will now return with exit code 1 [#66](https://github.com/wojciechkepka/pkger/pull/66)
 - `--quiet` flag now suppresses only container output, normal info output is still available [#67](https://github.com/wojciechkepka/pkger/pull/67)
 - `pkger build` will now display a warning with instructions on how to start a build [#68](https://github.com/wojciechkepka/pkger/pull/68)
+- Use appropriate cache dir on each OS to store images state [#71](https://github.com/wojciechkepka/pkger/pull/71)
 
 # 0.4.0
 - Add an option to sign RPMs with a GPG key [#55](https://github.com/wojciechkepka/pkger/pull/55)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,20 +271,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
 dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
@@ -1000,7 +999,7 @@ dependencies = [
  "clap",
  "colored",
  "ctrlc",
- "dirs-next",
+ "dirs",
  "futures 0.3.15",
  "pkger-core",
  "rpassword",

--- a/pkger-cli/Cargo.toml
+++ b/pkger-cli/Cargo.toml
@@ -21,7 +21,7 @@ colored = "2"
 ctrlc = "3"
 rpassword = "5"
 
-dirs-next = "2"
+dirs = "3"
 tempdir = "0.3"
 
 serde = {version = "1.0", features = ["derive"]}

--- a/pkger-cli/src/app.rs
+++ b/pkger-cli/src/app.rs
@@ -72,13 +72,16 @@ impl Application {
             .clone()
             .unwrap_or_else(|| _pkger_dir.path().join("images"));
 
+        let state_path = match dirs::cache_dir() {
+            Some(dir) => dir.join(DEFAULT_STATE_FILE),
+            None => PathBuf::from(DEFAULT_STATE_FILE),
+        };
+
         let images_state = Arc::new(RwLock::new(
-            match ImagesState::try_from_path(DEFAULT_STATE_FILE)
-                .context("failed to load images state")
-            {
+            match ImagesState::try_from_path(state_path).context("failed to load images state") {
                 Ok(state) => state,
                 Err(e) => {
-                    warn!(msg = %e);
+                    warn!(msg = ?e);
                     Default::default()
                 }
             },

--- a/pkger-cli/src/main.rs
+++ b/pkger-cli/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
 
     // config
     let config_path = opts.config.clone().unwrap_or_else(|| {
-        match dirs_next::home_dir() {
+        match dirs::home_dir() {
             Some(home_dir) => {
                 home_dir.join(DEFAULT_CONFIG_FILE).to_string_lossy().to_string()
             }

--- a/pkger-core/src/image/state.rs
+++ b/pkger-core/src/image/state.rs
@@ -6,7 +6,7 @@ use crate::{ErrContext, Result};
 
 use std::collections::{HashMap, HashSet};
 use std::convert::AsRef;
-use std::fs::{self, File};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -106,18 +106,18 @@ impl Default for ImagesState {
 }
 
 impl ImagesState {
-    /// Tries to initialize images state from the given path
+    /// Tries to initialize images state from the given path, if the path doesn't exist creates
+    /// a new ImagesState.
     pub fn try_from_path<P: AsRef<Path>>(state_file: P) -> Result<Self> {
         let state_file = state_file.as_ref();
         if !state_file.exists() {
-            trace!("state file doesn't exist, creating");
-            File::create(state_file)?;
-
+            debug!("state file doesn't exist");
             return Ok(ImagesState {
                 images: HashMap::new(),
                 state_file: state_file.to_path_buf(),
             });
         }
+        debug!("loading state");
         let contents =
             fs::read(state_file).context("failed to read images state file from the filesystem")?;
         let state =


### PR DESCRIPTION
This PR changes how the state file is stored. Previously the state would be saved to the current working directory, now if the cache directory is available the state will be stored there so that no matter from where one invokes pkger it will still read the same state file. Current working directory was left as a fallback.

Closes: #70