### PR TITLE
Automatically calculate `Installed-Size` field of DEB control file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `--quiet` flag now suppresses only container output, normal info output is still available [#67](https://github.com/wojciechkepka/pkger/pull/67)
 - `pkger build` will now display a warning with instructions on how to start a build [#68](https://github.com/wojciechkepka/pkger/pull/68)
 - Use appropriate cache dir on each OS to store images state [#71](https://github.com/wojciechkepka/pkger/pull/71)
+- Automatically calculate `Installed-Size` when building DEB packages [#72](https://github.com/wojciechkepka/pkger/pull/72)
 
 # 0.4.0
 - Add an option to sign RPMs with a GPG key [#55](https://github.com/wojciechkepka/pkger/pull/55)

--- a/docs/src/deb.md
+++ b/docs/src/deb.md
@@ -5,7 +5,6 @@ Optional fields that may be used when building a DEB package.
 ```yaml
   deb:
     priority: ""
-    installed_size: ""
     built_using: ""
     essential: true
     

--- a/pkger-cli/src/gen.rs
+++ b/pkger-cli/src/gen.rs
@@ -53,7 +53,6 @@ pub fn recipe(opts: Box<GenRecipeOpts>) -> Result<()> {
 
     let deb = DebRep {
         priority: opts.priority,
-        installed_size: opts.installed_size,
         built_using: opts.built_using,
         essential: opts.essential,
 

--- a/pkger-core/src/recipe/metadata.rs
+++ b/pkger-core/src/recipe/metadata.rs
@@ -119,7 +119,6 @@ impl TryFrom<PkgRep> for PkgInfo {
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct DebRep {
     pub priority: Option<String>,
-    pub installed_size: Option<String>,
     pub built_using: Option<String>,
     pub essential: Option<bool>,
 
@@ -134,7 +133,6 @@ pub struct DebRep {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DebInfo {
     pub priority: Option<String>,
-    pub installed_size: Option<String>,
     pub built_using: Option<String>,
     pub essential: Option<bool>,
 
@@ -152,7 +150,6 @@ impl TryFrom<DebRep> for DebInfo {
     fn try_from(rep: DebRep) -> Result<Self> {
         Ok(Self {
             priority: rep.priority,
-            installed_size: rep.installed_size,
             built_using: rep.built_using,
             essential: rep.essential,
 

--- a/pkger-core/src/recipe/mod.rs
+++ b/pkger-core/src/recipe/mod.rs
@@ -157,7 +157,7 @@ impl Recipe {
 }
 
 impl Recipe {
-    pub fn as_deb_control(&self, image: &str) -> BinaryDebControl {
+    pub fn as_deb_control(&self, image: &str, installed_size: Option<&str>) -> BinaryDebControl {
         let mut builder = DebControlBuilder::binary_package_builder(&self.metadata.name)
             .version(&self.metadata.version)
             .revision(self.metadata.release())
@@ -185,13 +185,13 @@ impl Recipe {
         if let Some(homepage) = &self.metadata.url {
             builder = builder.homepage(homepage);
         }
+        if let Some(installed_size) = installed_size {
+            builder = builder.installed_size(installed_size)
+        }
 
         if let Some(deb) = &self.metadata.deb {
             if let Some(priority) = &deb.priority {
                 builder = builder.priority(priority);
-            }
-            if let Some(installed_size) = &deb.installed_size {
-                builder = builder.installed_size(installed_size);
             }
             if let Some(built_using) = &deb.built_using {
                 builder = builder.built_using(built_using);


### PR DESCRIPTION
Users can no longer specify it in the recipe.