### PR TITLE
Define images in the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Users can now specify `filter` in the configuration so that if one wants to format the output in a particular way on
   each build they don't have to pass the `--filter` CLI parameter every time.
 - Fix a typo in deb field - `enchances` -> `enhances`  
+- Images are now be defined in the global configuration file. Previously users would have to define an image with a
+  target or os on each recipe, now recipe only requires the image name , and the definition is in the configuration.
+  [#73](https://github.com/vv9k/pkger/pull/73)
 
 # 0.4.0
 - Add an option to sign RPMs with a GPG key [#55](https://github.com/vv9k/pkger/pull/55)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -28,6 +28,18 @@ ssh:
 
   # This will allow tools that use SSH to connect to hosts that are not present in the `known_hosts` file
   disable_key_verification: true
+
+
+# To define custom images add the following
+images:
+  - name: centos8
+    target: rpm
+  - name: debian10
+    target: deb
+# if pkger fails to find out the operating system you can specify it by os parameter
+  - name: arch
+    target: pkg
+    os: Arch Linux
 ```
 
 The required fields when running a build are `recipes_dir` and `output_dir`. First tells **pkger** where to look for

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -18,16 +18,7 @@ To specify which images a recipe should use add images parameter with a list of 
 when building with `--simple` flag.
 
 ```yaml
-  images:
-    - name: centos8
-      target: rpm
-    - name: debian10
-      target: deb
-
-    # if pkger fails to find out the operating system you can specify it by os parameter
-    - name: arch
-      target: pkg
-      os: Arch
+  images: [ centos8, debian10 ]
 ```
 
 ### sources

--- a/example/conf.yml
+++ b/example/conf.yml
@@ -2,3 +2,11 @@ images_dir: "example/images"
 recipes_dir: "example/recipes"
 output_dir: "example/output"
 
+images:
+  - name: arch
+    target: pkg
+    os: Arch Linux
+  - name: centos8
+    target: rpm
+  - name: debian10
+    target: deb

--- a/example/recipes/pkger-custom-images/recipe.yml
+++ b/example/recipes/pkger-custom-images/recipe.yml
@@ -9,13 +9,7 @@ metadata:
   maintainer: "Wojciech Kępka <wojciech@wkepka.dev>"
   provides:
     - pkger
-  images:
-    - name: centos8
-      target: rpm
-    - name: debian10
-      target: deb
-    - name: arch
-      target: pkg
+  images: [ arch, centos8, debian10 ]
   depends:
     debian10:
       - libssl-dev

--- a/example/recipes/test-package/recipe.yml
+++ b/example/recipes/test-package/recipe.yml
@@ -5,11 +5,7 @@ metadata:
   description: pkger test package
   arch: x86_64
   license: MIT
-  images:
-    - name: centos8
-      target: rpm
-    - name: debian10
-      target: deb
+  images: [ centos8, debian10 ]
 build:
   steps: []
 install:

--- a/example/recipes/test-suite/recipe.yml
+++ b/example/recipes/test-suite/recipe.yml
@@ -8,9 +8,7 @@ metadata:
   exclude:
     - share
     - info
-  images:
-    - name: debian10
-    - name: centos8
+  images: [ debian10, centos8 ]
 env:
   ENV_VAR_TEST: 'test.com:1010'
 configure:

--- a/pkger-cli/src/app.rs
+++ b/pkger-cli/src/app.rs
@@ -187,11 +187,20 @@ impl Application {
             debug!("building all recipes for all targets");
             for recipe in &recipes {
                 if let Some(images) = &recipe.metadata.images {
-                    for target in images {
-                        tasks.push(BuildTask::Custom {
-                            recipe: recipe.clone(),
-                            target: target.clone(),
-                        });
+                    for target_image in images {
+                        if let Some(target) = self
+                            .config
+                            .images
+                            .iter()
+                            .find(|target| &target.image == target_image)
+                        {
+                            tasks.push(BuildTask::Custom {
+                                recipe: recipe.clone(),
+                                target: target.clone(),
+                            });
+                        } else {
+                            warn!(image = %target_image, "not found in configuration");
+                        }
                     }
                 } else {
                     warn!(recipe = %recipe.metadata.name, "recipe has no image targets, skipping");
@@ -213,11 +222,22 @@ impl Application {
             for recipe in &recipes {
                 if let Some(images) = &recipe.metadata.images {
                     for image in opt_images {
-                        if let Some(target) = images.iter().find(|target| &target.image == image) {
-                            tasks.push(BuildTask::Custom {
-                                recipe: recipe.clone(),
-                                target: target.clone(),
-                            });
+                        // first we check if the recipe contains the image
+                        if images.iter().any(|target| target == image) {
+                            // then we fetch the target from configuration images
+                            if let Some(target) = self
+                                .config
+                                .images
+                                .iter()
+                                .find(|target| &target.image == image)
+                            {
+                                tasks.push(BuildTask::Custom {
+                                    recipe: recipe.clone(),
+                                    target: target.clone(),
+                                });
+                            } else {
+                                warn!(%image, "not found in configuration");
+                            }
                         }
                     }
                 } else {
@@ -232,11 +252,20 @@ impl Application {
                         warn!(recipe = %recipe.metadata.name, "recipe has no image targets, skipping");
                         continue;
                     }
-                    for target in images {
-                        tasks.push(BuildTask::Custom {
-                            recipe: recipe.clone(),
-                            target: target.clone(),
-                        });
+                    for target_image in images {
+                        if let Some(target) = self
+                            .config
+                            .images
+                            .iter()
+                            .find(|target| &target.image == target_image)
+                        {
+                            tasks.push(BuildTask::Custom {
+                                recipe: recipe.clone(),
+                                target: target.clone(),
+                            });
+                        } else {
+                            warn!(image = %target_image, "not found in configuration");
+                        }
                     }
                 } else {
                     warn!(recipe = %recipe.metadata.name, "recipe has no image targets, skipping");

--- a/pkger-cli/src/config.rs
+++ b/pkger-cli/src/config.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use pkger_core::recipe::{deserialize_images, ImageTarget};
 use pkger_core::ssh::SshConfig;
 
 use serde::Deserialize;
@@ -15,6 +16,8 @@ pub struct Configuration {
     pub gpg_key: Option<PathBuf>,
     pub gpg_name: Option<String>,
     pub ssh: Option<SshConfig>,
+    #[serde(deserialize_with = "deserialize_images")]
+    pub images: Vec<ImageTarget>,
 }
 
 impl Configuration {

--- a/pkger-core/src/recipe/metadata.rs
+++ b/pkger-core/src/recipe/metadata.rs
@@ -9,7 +9,7 @@ mod target;
 pub use arch::BuildArch;
 pub use deps::Dependencies;
 pub use git::GitSource;
-pub use image::ImageTarget;
+pub use image::{deserialize_images, ImageTarget};
 pub use os::{Distro, Os, PackageManager};
 pub use patches::{Patch, Patches};
 pub use target::BuildTarget;
@@ -38,7 +38,7 @@ pub struct MetadataRep {
     pub description: String,
     pub license: String,
 
-    pub images: Option<Vec<YamlValue>>,
+    pub images: Option<Vec<String>>,
 
     // Common optional
     pub maintainer: Option<String>,
@@ -216,7 +216,7 @@ pub struct Metadata {
     pub license: String,
     pub arch: BuildArch,
 
-    pub images: Option<Vec<ImageTarget>>,
+    pub images: Option<Vec<String>>,
     pub maintainer: Option<String>,
     /// The URL of the web site for this package
     pub url: Option<String>,
@@ -266,22 +266,12 @@ impl TryFrom<MetadataRep> for Metadata {
     type Error = Error;
 
     fn try_from(rep: MetadataRep) -> Result<Self> {
-        let images = if let Some(rep_images) = rep.images {
-            let mut images = vec![];
-            for image in rep_images.into_iter().map(ImageTarget::try_from) {
-                images.push(image?);
-            }
-            Some(images)
-        } else {
-            None
-        };
-
         Ok(Self {
             name: rep.name,
             version: rep.version,
             description: rep.description,
             license: rep.license,
-            images,
+            images: rep.images,
 
             arch: rep
                 .arch

--- a/pkger-core/src/recipe/metadata/target.rs
+++ b/pkger-core/src/recipe/metadata/target.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::{AsRef, TryFrom};
 
 #[derive(Copy, Clone, Deserialize, Serialize, Debug, Eq, PartialEq, Hash)]
+#[serde(rename_all = "lowercase")]
 pub enum BuildTarget {
     Rpm,
     Deb,

--- a/pkger-core/src/recipe/mod.rs
+++ b/pkger-core/src/recipe/mod.rs
@@ -5,8 +5,8 @@ mod metadata;
 pub use cmd::Command;
 pub use envs::Env;
 pub use metadata::{
-    BuildTarget, DebInfo, DebRep, Dependencies, Distro, GitSource, ImageTarget, Metadata,
-    MetadataRep, Os, PackageManager, Patch, Patches, PkgInfo, PkgRep, RpmInfo, RpmRep,
+    deserialize_images, BuildTarget, DebInfo, DebRep, Dependencies, Distro, GitSource, ImageTarget,
+    Metadata, MetadataRep, Os, PackageManager, Patch, Patches, PkgInfo, PkgRep, RpmInfo, RpmRep,
 };
 
 use crate::{Error, Result};


### PR DESCRIPTION
This PR changes the way custom images are defined. Now all images can be defined once in the configuration to avoid unnecessary repetition on each recipe. To specify that a recipe can be built for an image all that will be needed is the image name.

Check out the updated examples to learn more.