### PR TITLE
Add ability to use environment variables in some recipe fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Fix rpm build not working when packaging files with spaces.
 - Add an option to set `AutoReqProv` value during RPM build (used to disable automatic dependency processing).
 - Add `RECIPE`, `RECIPE_VERSION`, `RECIPE_RELEASE` environment variables that can be used during the build.
+- Enable usage of environment variables for `working_dir` and `source` fields of recipe. This can greatly reduce
+  the number of changes one has to make when adding a recipe for other version. [#74](https://github.com/vv9k/pkger/pull/74)
 
 # 0.4.0
 - Add an option to sign RPMs with a GPG key [#55](https://github.com/vv9k/pkger/pull/55)

--- a/docs/src/env.md
+++ b/docs/src/env.md
@@ -14,3 +14,12 @@ Some env variables will be available to use during the build like:
  - `$PKGER_OS_VERSION` version of the distribution if applies
  - `$PKGER_BLD_DIR` the build directory with fetched source or git repo in the container
  - `$PKGER_OUT_DIR` the final directory from which **pkger** will copy files to target package
+ - `$RECIPE` the name of the recipe that is built
+ - `$RECIPE_VERSION` the version of the recipe
+ - `$RECIPE_RELEASE` the release of the recipe
+
+When using environment variables for fields other than `cmd` it is required to wrap the variable in braces like so:
+```
+${This_Is_Correct}
+${ this-is-also-correct1 }
+```

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -47,6 +47,11 @@ archive like `.tar.gz` or `.tar.xz` or `.zip` it will be directly extracted to
     branch: dev
 ```
 
+[Environment variables](./env.md) are available for this fields so this is possible:
+```yaml
+  source: "https://github.com/vv9k/${RECIPE}/${RECIPE_VERSION}"
+```
+
 
 ### common
 

--- a/docs/src/scripts.md
+++ b/docs/src/scripts.md
@@ -15,9 +15,10 @@ be executed like:
 To set a working directory during the script phase set the `working_dir` parameter like so:
 ```yaml
   working_dir: /tmp
-
-  # you can also use the available pkger variables here
-  working_dir: $PKGER_BLD_DIR/test-123
+```
+[Environment variables](./env.md) are available for this field so this is possible:
+```yaml
+  working_dir: ${PKGER_BLD_DIR}/${RECIPE}-${RECIPE_VERSION}-${SOME_USER_DEFINED_VAR}
 ```
 
 To use a different shell to execute each command set the `shell` parameter:

--- a/example/recipes/test-package/recipe.yml
+++ b/example/recipes/test-package/recipe.yml
@@ -6,8 +6,13 @@ metadata:
   arch: x86_64
   license: MIT
   images: [ centos8, debian10 ]
+configure:
+  steps:
+    - cmd: mkdir -p $PKGER_OUT_DIR/$RECIPE_VERSION/$RECIPE
 build:
-  steps: []
+  working_dir: ${PKGER_OUT_DIR}/${RECIPE_VERSION}/${RECIPE}
+  steps:
+    - cmd: echo $PWD
 install:
   steps:
     - cmd: mkdir -p $PKGER_OUT_DIR/test/deb

--- a/pkger-core/src/build/remote.rs
+++ b/pkger-core/src/build/remote.rs
@@ -2,6 +2,7 @@ use crate::archive::create_tarball;
 use crate::build::container::{checked_exec, Context};
 use crate::container::ExecOpts;
 use crate::recipe::GitSource;
+use crate::template;
 use crate::Result;
 
 use std::fs;
@@ -75,6 +76,7 @@ pub async fn fetch_source(ctx: &Context<'_>) -> Result<()> {
         if let Some(repo) = &ctx.build.recipe.metadata.git {
             fetch_git_source(ctx, repo).await?;
         } else if let Some(source) = &ctx.build.recipe.metadata.source {
+            let source = template::render(source, ctx.vars.inner());
             if source.starts_with("http") {
                 fetch_http_source(ctx, source.as_str(), &ctx.build.container_tmp_dir).await?;
             } else {

--- a/pkger-core/src/build/scripts.rs
+++ b/pkger-core/src/build/scripts.rs
@@ -1,5 +1,6 @@
 use crate::build::container::{checked_exec, Context};
 use crate::container::ExecOpts;
+use crate::template;
 use crate::{Error, Result};
 
 use std::path::PathBuf;
@@ -15,14 +16,9 @@ macro_rules! run_script {
             let mut _dir;
 
             if let Some(dir) = &$script.working_dir {
-                trace!(working_dir = %dir.display());
-                let dir_s = dir.to_string_lossy();
-                let bld_dir = $ctx.build.container_bld_dir.to_string_lossy();
-                let out_dir = $ctx.build.container_out_dir.to_string_lossy();
-                let mut dir_s = dir_s.replace("$PKGER_BLD_DIR", &bld_dir);
-                dir_s = dir_s.replace("$PKGER_OUT_DIR", &out_dir);
-                _dir = PathBuf::from(dir_s);
-                opts = opts.working_dir(_dir.as_path());
+                _dir = PathBuf::from(template::render(dir.to_string_lossy(), $ctx.vars.inner()));
+                trace!(working_dir = %_dir.display());
+                opts = opts.working_dir(&_dir);
             } else {
                 trace!(working_dir = %$dir.display(), "using default");
                 opts = opts.working_dir($dir);

--- a/pkger-core/src/lib.rs
+++ b/pkger-core/src/lib.rs
@@ -10,5 +10,6 @@ pub mod image;
 pub mod oneshot;
 pub mod recipe;
 pub mod ssh;
+pub mod template;
 
 pub use anyhow::{anyhow, Context as ErrContext, Error, Result};

--- a/pkger-core/src/recipe/envs.rs
+++ b/pkger-core/src/recipe/envs.rs
@@ -55,6 +55,14 @@ impl Env {
             .map(|(k, v)| format!("{}={}", k, v))
             .collect()
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
+        self.0.iter()
+    }
+
+    pub fn inner(&self) -> &HashMap<String, String> {
+        &self.0
+    }
 }
 
 #[cfg(test)]

--- a/pkger-core/src/template/lexer.rs
+++ b/pkger-core/src/template/lexer.rs
@@ -10,7 +10,7 @@ impl<'text> Lexer<'text> {
         Self { text, pos: 0 }
     }
 
-    pub fn next_token(&mut self) -> Option<Token> {
+    pub fn next_token(&mut self) -> Token {
         self.parse_token()
     }
 
@@ -40,14 +40,13 @@ impl<'text> Lexer<'text> {
         self.pos == self.text.len()
     }
 
-    fn parse_token(&mut self) -> Option<Token> {
+    fn parse_token(&mut self) -> Token {
         if self.cur() == '$' {
             self.next_pos();
-            Some(self.parse_variable())
+            self.parse_variable()
+        } else if self.is_eof() {
+            Token::EOF
         } else {
-            if self.is_eof() {
-                return Some(Token::EOF);
-            }
             self.parse_text()
         }
     }
@@ -91,11 +90,11 @@ impl<'text> Lexer<'text> {
         Token::Text(&self.text[var_start..self.pos])
     }
 
-    fn parse_text(&mut self) -> Option<Token> {
+    fn parse_text(&mut self) -> Token {
         let start = self.pos;
         loop {
             if self.cur() == '$' || !self.next_pos() {
-                return Some(Token::Text(&self.text[start..self.pos]));
+                return Token::Text(&self.text[start..self.pos]);
             }
         }
     }
@@ -109,29 +108,23 @@ mod tests {
     fn simple_case() {
         let text = "this is my super ${ cool } text.";
         let mut lexer = Lexer::new(text);
+        assert_eq!(lexer.next_token(), Token::Text("this is my super "));
         assert_eq!(
-            lexer.next_token().unwrap(),
-            Token::Text("this is my super ")
-        );
-        assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new("${ cool }", "cool"))
         );
-        assert_eq!(lexer.next_token().unwrap(), Token::Text(" text."));
-        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
-        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+        assert_eq!(lexer.next_token(), Token::Text(" text."));
+        assert_eq!(lexer.next_token(), Token::EOF);
+        assert_eq!(lexer.next_token(), Token::EOF);
         lexer.restart();
+        assert_eq!(lexer.next_token(), Token::Text("this is my super "));
         assert_eq!(
-            lexer.next_token().unwrap(),
-            Token::Text("this is my super ")
-        );
-        assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new("${ cool }", "cool"))
         );
-        assert_eq!(lexer.next_token().unwrap(), Token::Text(" text."));
-        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
-        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+        assert_eq!(lexer.next_token(), Token::Text(" text."));
+        assert_eq!(lexer.next_token(), Token::EOF);
+        assert_eq!(lexer.next_token(), Token::EOF);
     }
 
     #[test]
@@ -140,52 +133,52 @@ mod tests {
         It includes multiple ${lines} and ${ variables }."#;
 
         let mut lexer = Lexer::new(text);
-        assert_eq!(lexer.next_token().unwrap(), Token::Text("this is a "));
+        assert_eq!(lexer.next_token(), Token::Text("this is a "));
         assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new("${much}", "much"))
         );
-        assert_eq!(lexer.next_token().unwrap(), Token::Text(" more "));
+        assert_eq!(lexer.next_token(), Token::Text(" more "));
         assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new("${ complex }", "complex"))
         );
         assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Text(" case.\n        It includes multiple ")
         );
         assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new("${lines}", "lines"))
         );
-        assert_eq!(lexer.next_token().unwrap(), Token::Text(" and "));
+        assert_eq!(lexer.next_token(), Token::Text(" and "));
         assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new("${ variables }", "variables"))
         );
-        assert_eq!(lexer.next_token().unwrap(), Token::Text("."));
-        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+        assert_eq!(lexer.next_token(), Token::Text("."));
+        assert_eq!(lexer.next_token(), Token::EOF);
     }
 
     #[test]
     fn corner_cases() {
         let text = "this ${should be just text$}${123this_is-CorrecT }${}";
         let mut lexer = Lexer::new(text);
-        assert_eq!(lexer.next_token().unwrap(), Token::Text("this "));
-        assert_eq!(lexer.next_token().unwrap(), Token::Text("${should"));
-        assert_eq!(lexer.next_token().unwrap(), Token::Text(" be just text"));
-        assert_eq!(lexer.next_token().unwrap(), Token::Text("$}"));
+        assert_eq!(lexer.next_token(), Token::Text("this "));
+        assert_eq!(lexer.next_token(), Token::Text("${should"));
+        assert_eq!(lexer.next_token(), Token::Text(" be just text"));
+        assert_eq!(lexer.next_token(), Token::Text("$}"));
         assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new(
                 "${123this_is-CorrecT }",
                 "123this_is-CorrecT"
             )),
         );
         assert_eq!(
-            lexer.next_token().unwrap(),
+            lexer.next_token(),
             Token::Variable(Variable::new("${}", ""))
         );
-        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+        assert_eq!(lexer.next_token(), Token::EOF);
     }
 }

--- a/pkger-core/src/template/lexer.rs
+++ b/pkger-core/src/template/lexer.rs
@@ -1,0 +1,191 @@
+use crate::template::{Token, Variable};
+
+pub struct Lexer<'text> {
+    text: &'text str,
+    pos: usize,
+}
+
+impl<'text> Lexer<'text> {
+    pub fn new(text: &'text str) -> Self {
+        Self { text, pos: 0 }
+    }
+
+    pub fn next_token(&mut self) -> Option<Token> {
+        self.parse_token()
+    }
+
+    #[allow(dead_code)]
+    pub fn restart(&mut self) {
+        self.pos = 0;
+    }
+
+    fn next_pos(&mut self) -> bool {
+        if self.pos < self.text.len() {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.text.chars().nth(self.pos + 1)
+    }
+
+    fn cur(&self) -> char {
+        self.text.chars().nth(self.pos).unwrap_or_default()
+    }
+
+    fn is_eof(&self) -> bool {
+        self.pos == self.text.len()
+    }
+
+    fn parse_token(&mut self) -> Option<Token> {
+        if self.cur() == '$' {
+            self.next_pos();
+            Some(self.parse_variable())
+        } else {
+            if self.is_eof() {
+                return Some(Token::EOF);
+            }
+            self.parse_text()
+        }
+    }
+
+    fn parse_variable(&mut self) -> Token {
+        let var_start = self.pos - 1;
+
+        if self.cur() == '{' {
+            self.next_pos();
+            if self.cur() == ' ' {
+                self.next_pos();
+            }
+            loop {
+                let cur = self.cur();
+                let ok = if cur == '}' {
+                    self.next_pos();
+                    true
+                } else if cur.is_ascii_whitespace() && self.peek() == Some('}') {
+                    self.next_pos();
+                    self.next_pos();
+                    true
+                } else {
+                    false
+                };
+
+                if ok {
+                    return Token::Variable(Variable::new(
+                        &self.text[var_start..self.pos],
+                        self.text[var_start + 2..self.pos - 1].trim(),
+                    ));
+                } else if (!cur.is_ascii_alphanumeric() && cur != '_' && cur != '-')
+                    || !self.next_pos()
+                {
+                    return Token::Text(&self.text[var_start..self.pos]);
+                }
+            }
+        }
+
+        self.next_pos();
+
+        Token::Text(&self.text[var_start..self.pos])
+    }
+
+    fn parse_text(&mut self) -> Option<Token> {
+        let start = self.pos;
+        loop {
+            if self.cur() == '$' || !self.next_pos() {
+                return Some(Token::Text(&self.text[start..self.pos]));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_case() {
+        let text = "this is my super ${ cool } text.";
+        let mut lexer = Lexer::new(text);
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Text("this is my super ")
+        );
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new("${ cool }", "cool"))
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::Text(" text."));
+        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+        lexer.restart();
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Text("this is my super ")
+        );
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new("${ cool }", "cool"))
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::Text(" text."));
+        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+    }
+
+    #[test]
+    fn multiple_vars() {
+        let text = r#"this is a ${much} more ${ complex } case.
+        It includes multiple ${lines} and ${ variables }."#;
+
+        let mut lexer = Lexer::new(text);
+        assert_eq!(lexer.next_token().unwrap(), Token::Text("this is a "));
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new("${much}", "much"))
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::Text(" more "));
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new("${ complex }", "complex"))
+        );
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Text(" case.\n        It includes multiple ")
+        );
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new("${lines}", "lines"))
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::Text(" and "));
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new("${ variables }", "variables"))
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::Text("."));
+        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+    }
+
+    #[test]
+    fn corner_cases() {
+        let text = "this ${should be just text$}${123this_is-CorrecT }${}";
+        let mut lexer = Lexer::new(text);
+        assert_eq!(lexer.next_token().unwrap(), Token::Text("this "));
+        assert_eq!(lexer.next_token().unwrap(), Token::Text("${should"));
+        assert_eq!(lexer.next_token().unwrap(), Token::Text(" be just text"));
+        assert_eq!(lexer.next_token().unwrap(), Token::Text("$}"));
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new(
+                "${123this_is-CorrecT }",
+                "123this_is-CorrecT"
+            )),
+        );
+        assert_eq!(
+            lexer.next_token().unwrap(),
+            Token::Variable(Variable::new("${}", ""))
+        );
+        assert_eq!(lexer.next_token().unwrap(), Token::EOF);
+    }
+}

--- a/pkger-core/src/template/mod.rs
+++ b/pkger-core/src/template/mod.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+mod lexer;
+
+#[derive(Debug, PartialEq)]
+pub struct Variable<'text> {
+    text: &'text str,
+    name: &'text str,
+}
+
+impl<'text> Variable<'text> {
+    pub fn new(text: &'text str, name: &'text str) -> Self {
+        Self { text, name }
+    }
+
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn text(&self) -> &str {
+        self.text
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Token<'text> {
+    Variable(Variable<'text>),
+    Text(&'text str),
+    EOF,
+}
+
+pub fn render<T, V>(text: T, vars: &HashMap<String, V>) -> String
+where
+    T: AsRef<str>,
+    V: AsRef<str>,
+{
+    let mut lexer = lexer::Lexer::new(text.as_ref());
+    let mut rendered = String::new();
+
+    loop {
+        match lexer.next_token() {
+            Some(Token::Text(txt)) => rendered.push_str(txt),
+            Some(Token::Variable(var)) => {
+                if let Some(value) = vars.get(var.name()) {
+                    rendered.push_str(value.as_ref());
+                } else {
+                    rendered.push_str(var.text());
+                }
+            }
+            None => {}
+            Some(Token::EOF) => break,
+        }
+    }
+
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::template::render;
+    use std::collections::HashMap;
+
+    #[test]
+    fn renders_vars() {
+        let text = "cd $TEST_VAR/${PKGER_BLD_DIR}/${ RECIPE }/${ RECIPE_VERSION}${DOESNT_EXIST}";
+        let mut vars = HashMap::new();
+        vars.insert("PKGER_BLD_DIR".to_string(), "/tmp/test".to_string());
+        vars.insert("RECIPE".to_string(), "pkger-test".to_string());
+        vars.insert("RECIPE_VERSION".to_string(), "0.1.0".to_string());
+
+        assert_eq!(
+            render(text, &vars),
+            "cd $TEST_VAR//tmp/test/pkger-test/0.1.0${DOESNT_EXIST}".to_string()
+        );
+    }
+}

--- a/pkger-core/src/template/mod.rs
+++ b/pkger-core/src/template/mod.rs
@@ -39,16 +39,15 @@ where
 
     loop {
         match lexer.next_token() {
-            Some(Token::Text(txt)) => rendered.push_str(txt),
-            Some(Token::Variable(var)) => {
+            Token::Text(txt) => rendered.push_str(txt),
+            Token::Variable(var) => {
                 if let Some(value) = vars.get(var.name()) {
                     rendered.push_str(value.as_ref());
                 } else {
                     rendered.push_str(var.text());
                 }
             }
-            None => {}
-            Some(Token::EOF) => break,
+            Token::EOF => break,
         }
     }
 


### PR DESCRIPTION
This PR enables usage of environment variables in `source` and  `working_dir` fields of recipe. This works for both user defined variables in the `env` field as well as the default variables that are added to each container.