### PR TITLE
Add alpine APK target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
         run: cargo run -- --filter sf -t -c example/conf.yml build test-suite
       - name: Build the test package
         run: cargo run -- --filter sf -t -c example/conf.yml build test-package
+      - name: Build simple APK and PKG
+        run: cargo run -- --filter sf -t -c example/conf.yml build -s apk pkg -- test-package
       - name: Verify DEB package
         run: |
           sudo dpkg -i example/output/debian10/test-package-0.1.0.amd64.deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Don't use `setarch` when arch is all/noarch
 - Make Ctrl-C cancellation instantaneous, no more waiting for the jobs to finish
 - Use Rocky Linux for simple RPM builds
+- Add alpine APK target [#75](https://github.com/vv9k/pkger/pull/75)
 
 # 0.6.0
 - Use default OS config directory instead of home directory to read the configuration file by default.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
+name = "apkbuild"
+version = "0.1.0"
+dependencies = [
+ "paste",
+ "pkgspec",
+ "pretty_assertions",
+]
+
+[[package]]
 name = "async-mutex"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1051,7 @@ name = "pkger-core"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "apkbuild",
  "async-rwlock",
  "deb-control",
  "docker-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "libs/pkgspec",
     "libs/rpmspec",
     "libs/debcontrol",
-    "libs/pkgbuild"
+    "libs/pkgbuild",
+    "libs/apkbuild"
 ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://github.com/vv9k/pkger/actions/workflows/docs.yml/badge.svg)](https://vv9k.github.io/pkger/)
 [![Build Status](https://github.com/vv9k/pkger/workflows/pkger%20CI/badge.svg)](https://github.com/vv9k/pkger/actions?query=workflow%3A%22pkger+CI%22)
 
-**pkger** is a tool that automates building *RPMs*, *DEBs*, *PKG*, and other packages on multiple *Linux* distributions, versions and architectures with the help of Docker.
+**pkger** is a tool that automates building *RPMs*, *DEBs*, *PKG*, *APK* and other packages on multiple *Linux* distributions, versions and architectures with the help of Docker.
 
 To learn more about **pkger** head over to the [user guide](https://vv9k.github.io/pkger/).
 

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -114,9 +114,8 @@ if running a simple build and there is a need to specify dependencies for the ta
 images:
 
 ```yaml
-    pkger-rpm: ["cargo"]
+    pkger-rpm+pkger-apk+pkger-pkg: ["cargo"]
     pkger-deb: ["curl"]
-    pkger-pkg: ["cargo"]
     pkger-gzip: []
 ```
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -1,6 +1,6 @@
 # Build a package
 
-Currently available targets are: **RPM**, **DEB**, **PKG**, **GZIP**.  
+Currently available targets are: **rpm**, **deb**, **pkg**, **apk**, **gzip**.
 
 ### Simple build
 

--- a/libs/apkbuild/Cargo.toml
+++ b/libs/apkbuild/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "apkbuild"
+description = "Crate for APKBUILD generation"
+version = "0.1.0"
+authors = ["Wojciech Kępka <wojciech@wkepka.dev>"]
+edition = "2018"
+license = "MIT"
+
+[dependencies]
+pkgspec = { path = "../pkgspec" }
+paste = "1"
+
+[dev-dependencies]
+pretty_assertions = "0.3"

--- a/libs/apkbuild/LICENSE
+++ b/libs/apkbuild/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright 2021 Wojciech Kępka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.T

--- a/libs/apkbuild/src/lib.rs
+++ b/libs/apkbuild/src/lib.rs
@@ -1,0 +1,189 @@
+use pkgspec::SpecStruct;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[derive(Clone, Debug, Default, PartialEq, SpecStruct)]
+pub struct ApkBuild {
+    #[skip]
+    /// Name of this packages or names if split packages
+    pkgname: String,
+    /// The version of the software. The variable is not allowed to contain colons,
+    /// forward slashes, hyphens or whitespace
+    pkgver: String,
+    /// Release number of the package
+    pkgrel: String,
+    /// Architectures on which the given package is available
+    arch: Vec<String>,
+    /// A brief description of the package
+    pkgdesc: String,
+    /// The url pointing to the website of the package
+    url: String,
+    /// License(s) of the package
+    license: Vec<String>,
+    /// A list of source files required to build the package
+    source: Vec<String>,
+    /// If the package contains pre/post install scripts this field should contain the install
+    /// variables.
+    install: Option<String>,
+
+    /// Subpackages are made to split up the normal "make install" into separate packages. The most
+    /// common subpackages we use are doc and dev
+    subpackages: Vec<String>,
+
+    /// A list of patches to apply to the package
+    patches: Vec<String>,
+
+    /// A list of packages this package depends on to run
+    depends: Vec<String>,
+    /// A list of packages this package depends on to build
+    makedepends: Vec<String>,
+
+    /// Directory used during prepare/build/install phases
+    builddir: String,
+
+    /// Specifies the prepare script of the package
+    prepare_func: Option<String>,
+    /// Specifies the check script of the package
+    check_func: Option<String>,
+    /// Specifies the build script of the package
+    build_func: Option<String>,
+    /// Specifies the package script of the package
+    package_func: Option<String>,
+}
+
+impl ApkBuild {
+    /// Renders this APKBUILD and saves it to the given path
+    pub fn save_to<P>(&self, path: P) -> io::Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        fs::write(path, self.render())
+    }
+
+    /// Renders this APKBUILD
+    pub fn render(&self) -> String {
+        let mut pkg = String::new();
+
+        macro_rules! format_value {
+            ($key:expr, $value:ident) => {
+                if $value.contains(|c: char| c.is_ascii_whitespace() || c == '$') {
+                    pkg.push_str(&format!("{}=\"{}\"\n", $key, &$value));
+                } else {
+                    pkg.push_str(&format!("{}={}\n", $key, &$value));
+                }
+            };
+        }
+
+        macro_rules! push_field {
+            ($field:ident) => {
+                let f = &self.$field;
+                format_value!(stringify!($field), f);
+            };
+        }
+
+        macro_rules! push_if_some {
+            ($field:ident) => {
+                if let Some(value) = &self.$field {
+                    format_value!(stringify!($field), value);
+                }
+            };
+        }
+
+        macro_rules! push_array {
+            ($field:ident) => {
+                if !self.$field.is_empty() {
+                    pkg.push_str(&format!(
+                        "{}=\"{}\"\n",
+                        stringify!($field),
+                        self.$field.join(" ")
+                    ));
+                }
+            };
+        }
+
+        macro_rules! push_func {
+            ($field:ident) => {
+                pkg.push_str(&format!("\n{}() {{\n{}\n}}\n", stringify!($field), $field));
+            };
+        }
+
+        push_field!(pkgname);
+        push_field!(pkgver);
+        push_field!(pkgrel);
+        push_field!(pkgdesc);
+        push_field!(url);
+        push_array!(arch);
+        push_array!(license);
+        push_array!(depends);
+        push_array!(makedepends);
+        push_if_some!(install);
+        push_array!(subpackages);
+        push_array!(source);
+        push_array!(patches);
+        if self.builddir.is_empty() {
+            const BUILDDIR: &str = "$srcdir/";
+            format_value!("builddir", BUILDDIR);
+        } else {
+            push_field!(builddir);
+        }
+
+        if let Some(prepare) = &self.prepare_func {
+            push_func!(prepare);
+        }
+        if let Some(build) = &self.build_func {
+            push_func!(build);
+        }
+        if let Some(check) = &self.check_func {
+            push_func!(check);
+        }
+        if let Some(package) = &self.package_func {
+            push_func!(package);
+        }
+
+        pkg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn builds_a_apkbuild() {
+        let got = ApkBuild::builder()
+            .pkgname("apkbuild")
+            .pkgver("0.1.0")
+            .pkgrel("1")
+            .pkgdesc("short description...")
+            .url("https://some.invalid.url")
+            .add_license_entries(vec!["MIT"])
+            .add_depends_entries(vec!["rust", "cargo"])
+            .build_func("    echo test")
+            .check_func("    true\n    false")
+            .build()
+            .render();
+
+        let expect = r#"pkgname=apkbuild
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="short description..."
+url=https://some.invalid.url
+license="MIT"
+depends="rust cargo"
+builddir="$srcdir/"
+
+build() {
+    echo test
+}
+
+check() {
+    true
+    false
+}
+"#;
+
+        assert_eq!(expect, got);
+    }
+}

--- a/pkger-cli/src/metadata.rs
+++ b/pkger-cli/src/metadata.rs
@@ -14,6 +14,7 @@ lazy_static! {
     static ref PKG_RE: Regex =
         Regex::new(r"([\w_.+@-]+?)-(\d+[.]\d+[.]\d+)-(\d+)-([\w_-]+)").unwrap();
     static ref GZIP_RE: Regex = Regex::new(r"([\S]+?)-(\d+[.]\d+[.]\d+)").unwrap();
+    static ref APK_RE: Regex = Regex::new(r"([\w_.+@-]+?)-(\d+[.]\d+[.]\d+)-r(\d+)").unwrap();
 }
 
 #[cfg(unix)]
@@ -139,6 +140,18 @@ impl PackageMetadata {
                     name: captures[1].to_string(),
                     version: captures[2].to_string(),
                     release: None,
+                    arch: None,
+                    package_type,
+                    created,
+                    size,
+                }),
+            BuildTarget::Apk => APK_RE
+                .captures_iter(s)
+                .next()
+                .map(|captures| PackageMetadata {
+                    name: captures[1].to_string(),
+                    version: captures[2].to_string(),
+                    release: Some(captures[3].to_string()),
                     arch: None,
                     package_type,
                     created,

--- a/pkger-core/Cargo.toml
+++ b/pkger-core/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 deb-control = { path = "../libs/debcontrol" }
 rpmspec = { path = "../libs/rpmspec" }
 pkgbuild = { path = "../libs/pkgbuild" }
+apkbuild = { path = "../libs/apkbuild" }
 
 docker-api = "0.5"
 

--- a/pkger-core/src/build/deps.rs
+++ b/pkger-core/src/build/deps.rs
@@ -39,6 +39,11 @@ pub fn default(target: &BuildTarget, recipe: &Recipe, enable_gpg: bool) -> HashS
         BuildTarget::Pkg => {
             deps.insert("base-devel");
         }
+        BuildTarget::Apk => {
+            deps.insert("alpine-sdk");
+            deps.insert("sudo");
+            deps.insert("bash");
+        }
     }
     if recipe.metadata.git.is_some() {
         deps.insert("git");

--- a/pkger-core/src/build/package/apk.rs
+++ b/pkger-core/src/build/package/apk.rs
@@ -1,0 +1,171 @@
+use crate::build::container::{checked_exec, create_dirs, Context};
+use crate::container::ExecOpts;
+use crate::image::ImageState;
+use crate::{ErrContext, Result};
+
+use std::path::{Path, PathBuf};
+use tracing::{debug, info, info_span, trace, Instrument};
+
+pub fn package_name(ctx: &Context<'_>, extension: bool) -> String {
+    format!(
+        "{}-{}-r{}{}",
+        &ctx.build.recipe.metadata.name,
+        &ctx.build.recipe.metadata.version,
+        &ctx.build.recipe.metadata.release(),
+        if extension { ".apk" } else { "" },
+    )
+}
+
+/// Creates a final APK package and saves it to `output_dir`
+pub(crate) async fn build(
+    ctx: &Context<'_>,
+    image_state: &ImageState,
+    output_dir: &Path,
+) -> Result<PathBuf> {
+    let package_name = package_name(ctx, false);
+
+    let span = info_span!("APK", package = %package_name);
+    async move {
+        info!("building APK package");
+
+        let tmp_dir = PathBuf::from(format!("/tmp/{}", package_name));
+        let src_dir = tmp_dir.join("src");
+        let bld_dir = tmp_dir.join("bld");
+
+        let source_tar_name = [&package_name, ".tar.gz"].join("");
+        let source_tar_path = bld_dir.join(&source_tar_name);
+
+        let dirs = [tmp_dir.as_path(), bld_dir.as_path(), src_dir.as_path()];
+
+        create_dirs(ctx, &dirs[..])
+            .await
+            .context("failed to create dirs")?;
+
+        trace!("copy source files to temporary location");
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd(&format!("cp -rv . {}", src_dir.display()))
+                .working_dir(&ctx.build.container_out_dir)
+                .build(),
+        )
+        .await
+        .context("failed to copy source files to temp directory")?;
+
+        trace!("prepare archived source files");
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd(&format!("tar -zcvf {} .", source_tar_path.display()))
+                .working_dir(src_dir.as_path())
+                .build(),
+        )
+        .await?;
+
+        let sources = vec![source_tar_name];
+        static BUILD_USER: &str = "builduser";
+
+        let apkbuild = ctx
+            .build
+            .recipe
+            .as_apkbuild(&image_state.image, &sources, &bld_dir)
+            .render();
+        debug!(APKBUILD = %apkbuild);
+
+        ctx.container
+            .upload_files(
+                vec![("APKBUILD".to_string(), apkbuild.as_bytes())],
+                &bld_dir,
+                ctx.build.quiet,
+            )
+            .await
+            .context("failed to upload APKBUILD to container")?;
+
+        trace!("create build user");
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd(&format!("adduser -D {}", BUILD_USER))
+                .build(),
+        )
+        .await?;
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd(&format!("passwd -d {}", BUILD_USER))
+                .build(),
+        )
+        .await?;
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd(&format!("chown -Rv {0}:{0} .", BUILD_USER))
+                .working_dir(bld_dir.as_path())
+                .build(),
+        )
+        .await?;
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd("chmod 644 APKBUILD")
+                .working_dir(bld_dir.as_path())
+                .build(),
+        )
+        .await?;
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd("abuild-keygen -an")
+                .user(BUILD_USER)
+                .build(),
+        )
+        .await?;
+
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd("cat APKBUILD && ls -l")
+                .working_dir(bld_dir.as_path())
+                .user(BUILD_USER)
+                .build(),
+        )
+        .await?;
+
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd("abuild checksum")
+                .working_dir(bld_dir.as_path())
+                .user(BUILD_USER)
+                .build(),
+        )
+        .await
+        .context("failed to calculate checksum")?;
+
+        trace!("abuild");
+        checked_exec(
+            ctx,
+            &ExecOpts::default()
+                .cmd("abuild")
+                .working_dir(bld_dir.as_path())
+                .user(BUILD_USER)
+                .build(),
+        )
+        .await
+        .context("failed to build APK package")?;
+
+        let apk = format!("{}.apk", package_name);
+        let apk_path = PathBuf::from(format!(
+            "/home/{}/packages/{}/{}/{}",
+            BUILD_USER, package_name, ctx.build.recipe.metadata.arch, apk
+        ));
+
+        ctx.container
+            .download_files(&apk_path, output_dir)
+            .await
+            .map(|_| output_dir.join(apk))
+            .context("failed to download finished package")
+    }
+    .instrument(span)
+    .await
+}

--- a/pkger-core/src/build/package/mod.rs
+++ b/pkger-core/src/build/package/mod.rs
@@ -5,6 +5,7 @@ use crate::image::ImageState;
 use crate::recipe::BuildTarget;
 use crate::Result;
 
+pub mod apk;
 pub mod deb;
 pub mod gzip;
 pub mod pkg;
@@ -21,5 +22,6 @@ pub async fn create_package(
         BuildTarget::Gzip => gzip::build(ctx, output_dir).await,
         BuildTarget::Deb => deb::build(ctx, image_state, output_dir).await,
         BuildTarget::Pkg => pkg::build(ctx, image_state, output_dir).await,
+        BuildTarget::Apk => apk::build(ctx, image_state, output_dir).await,
     }
 }

--- a/pkger-core/src/image/mod.rs
+++ b/pkger-core/src/image/mod.rs
@@ -30,6 +30,7 @@ impl Image {
             BuildTarget::Deb => ("ubuntu:latest", "pkger-deb"),
             BuildTarget::Pkg => ("archlinux", "pkger-pkg"),
             BuildTarget::Gzip => ("ubuntu:latest", "pkger-gzip"),
+            BuildTarget::Apk => ("alpine:latest", "pkger-apk"),
         }
     }
 

--- a/pkger-core/src/recipe/cmd.rs
+++ b/pkger-core/src/recipe/cmd.rs
@@ -19,6 +19,7 @@ pub struct Command {
     pub deb: Option<bool>,
     pub pkg: Option<bool>,
     pub gzip: Option<bool>,
+    pub apk: Option<bool>,
 }
 
 impl From<&str> for Command {
@@ -30,6 +31,7 @@ impl From<&str> for Command {
             deb: None,
             pkg: None,
             gzip: None,
+            apk: None,
         }
     }
 }
@@ -47,6 +49,7 @@ impl Command {
             BuildTarget::Deb => self.deb,
             BuildTarget::Pkg => self.pkg,
             BuildTarget::Gzip => self.gzip,
+            BuildTarget::Apk => self.apk,
         }
         .unwrap_or_default()
     }
@@ -62,17 +65,21 @@ mod tests {
         assert!(cmd.should_run_on(&BuildTarget::Rpm));
         assert!(cmd.should_run_on(&BuildTarget::Pkg));
         assert!(cmd.should_run_on(&BuildTarget::Gzip));
+        assert!(cmd.should_run_on(&BuildTarget::Apk));
         cmd.rpm = Some(true);
         assert!(cmd.should_run_on(&BuildTarget::Rpm));
         assert!(!cmd.should_run_on(&BuildTarget::Gzip));
         assert!(!cmd.should_run_on(&BuildTarget::Pkg));
         assert!(!cmd.should_run_on(&BuildTarget::Deb));
+        assert!(!cmd.should_run_on(&BuildTarget::Apk));
         cmd.deb = Some(true);
         cmd.pkg = Some(true);
         cmd.gzip = Some(true);
+        cmd.apk = Some(true);
         assert!(cmd.should_run_on(&BuildTarget::Rpm));
         assert!(cmd.should_run_on(&BuildTarget::Gzip));
         assert!(cmd.should_run_on(&BuildTarget::Pkg));
         assert!(cmd.should_run_on(&BuildTarget::Deb));
+        assert!(cmd.should_run_on(&BuildTarget::Apk));
     }
 }

--- a/pkger-core/src/recipe/metadata/os.rs
+++ b/pkger-core/src/recipe/metadata/os.rs
@@ -45,6 +45,7 @@ impl Os {
             Distro::Fedora if version >= 22 => PackageManager::Dnf,
             Distro::Rocky => PackageManager::Dnf,
             Distro::RedHat | Distro::CentOS | Distro::Fedora => PackageManager::Yum,
+            Distro::Alpine => PackageManager::Apk,
         }
     }
 }
@@ -61,6 +62,7 @@ pub enum Distro {
     RedHat,
     Ubuntu,
     Rocky,
+    Alpine,
 }
 
 impl AsRef<str> for Distro {
@@ -74,6 +76,7 @@ impl AsRef<str> for Distro {
             RedHat => "redhat",
             Ubuntu => "ubuntu",
             Rocky => "rocky",
+            Alpine => "alpine",
         }
     }
 }
@@ -82,7 +85,7 @@ impl TryFrom<&str> for Distro {
     type Error = Error;
     fn try_from(s: &str) -> Result<Self> {
         use Distro::*;
-        const DISTROS: [(&str, Distro); 8] = [
+        const DISTROS: &[(&str, Distro)] = &[
             ("arch", Arch),
             ("centos", CentOS),
             ("debian", Debian),
@@ -91,6 +94,7 @@ impl TryFrom<&str> for Distro {
             ("red hat", RedHat),
             ("ubuntu", Ubuntu),
             ("rocky", Rocky),
+            ("alpine", Alpine),
         ];
         let out = s.to_lowercase();
         for (name, distro) in DISTROS.iter() {
@@ -111,6 +115,7 @@ pub enum PackageManager {
     Dnf,
     Pacman,
     Yum,
+    Apk,
 }
 
 impl AsRef<str> for PackageManager {
@@ -120,6 +125,7 @@ impl AsRef<str> for PackageManager {
             Self::Dnf => "dnf",
             Self::Pacman => "pacman",
             Self::Yum => "yum",
+            Self::Apk => "apk",
         }
     }
 }
@@ -132,6 +138,7 @@ impl PackageManager {
             Self::Dnf => vec!["install", "-y"],
             Self::Pacman => vec!["-S", "--noconfirm"],
             Self::Yum => vec!["install", "-y"],
+            Self::Apk => vec!["add"],
         }
     }
 
@@ -140,6 +147,7 @@ impl PackageManager {
             Self::Apt => vec!["update", "-y"],
             Self::Dnf | Self::Yum => vec!["clean", "metadata"],
             Self::Pacman => vec!["-Sy", "--noconfirm"],
+            Self::Apk => vec!["update"],
         }
     }
 
@@ -148,6 +156,7 @@ impl PackageManager {
             Self::Apt => vec!["dist-upgrade", "-y"],
             Self::Dnf | Self::Yum => vec!["update", "-y"],
             Self::Pacman => vec!["-Syu", "--noconfirm"],
+            Self::Apk => vec!["upgrade"],
         }
     }
 }

--- a/pkger-core/src/recipe/metadata/target.rs
+++ b/pkger-core/src/recipe/metadata/target.rs
@@ -10,6 +10,7 @@ pub enum BuildTarget {
     Deb,
     Gzip,
     Pkg,
+    Apk,
 }
 
 impl Default for BuildTarget {
@@ -27,6 +28,7 @@ impl TryFrom<&str> for BuildTarget {
             "deb" => Ok(Self::Deb),
             "gzip" => Ok(Self::Gzip),
             "pkg" => Ok(Self::Pkg),
+            "apk" => Ok(Self::Apk),
             target => Err(anyhow!("unknown build target `{}`", target)),
         }
     }
@@ -39,6 +41,7 @@ impl AsRef<str> for BuildTarget {
             BuildTarget::Deb => "deb",
             BuildTarget::Gzip => "gzip",
             BuildTarget::Pkg => "pkg",
+            BuildTarget::Apk => "apk",
         }
     }
 }


### PR DESCRIPTION
This PR adds support for building `apk` packages that can be installed on [Alpine Linux](https://www.alpinelinux.org/).

Closes: #47 