### PR TITLE
Add support for proxy environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Rename `docker_uri` configuration option to `runtime_uri`
 - Add `--podman` global option and `podman` boolean configuration option that decides wether Podman runtime should be used for containers.
 - `git` dependency is no longer needed in a build image as **pkger** will now clone the repository by itself and upload it to the container
+- Support for standard proxy environment variables like `http_proxy`, `https_proxy` and `no_proxy` when pulling a repository
 
 # 0.7.0
 - Add `DEBIAN_FRONTEND=noninteracitve` when doing a DEB build so that when `tzdata` is installed as dependency it won't stop a build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +944,8 @@ dependencies = [
  "flate2",
  "futures",
  "git2",
+ "http",
+ "ipnet",
  "lazy_static",
  "pkgbuild",
  "podman-api",

--- a/pkger-cli/src/app/build.rs
+++ b/pkger-cli/src/app/build.rs
@@ -198,6 +198,7 @@ impl Application {
                 is_simple,
                 self.gpg_key.clone(),
                 self.config.ssh.clone(),
+                self.proxy.clone(),
             );
             let id = ctx.id().to_string();
 

--- a/pkger-cli/src/app/mod.rs
+++ b/pkger-cli/src/app/mod.rs
@@ -10,6 +10,7 @@ use pkger_core::gpg::GpgKey;
 use pkger_core::image::Image;
 use pkger_core::image::{state::DEFAULT_STATE_FILE, ImagesState};
 use pkger_core::log::{error, info, trace, warning, BoxedCollector, Level};
+use pkger_core::proxy::ProxyConfig;
 use pkger_core::recipe;
 use pkger_core::runtime::{self, ConnectionPool};
 use pkger_core::{ErrContext, Error, Result};
@@ -174,6 +175,7 @@ pub struct Application {
     app_dir: TempDir,
     gpg_key: Option<GpgKey>,
     session_id: Uuid,
+    proxy: ProxyConfig,
 }
 
 impl Application {
@@ -215,6 +217,7 @@ impl Application {
             app_dir,
             gpg_key: None,
             session_id: Uuid::new_v4(),
+            proxy: ProxyConfig::from_env(),
         };
         let is_running = app.is_running.clone();
         set_ctrlc_handler(is_running);

--- a/pkger-core/Cargo.toml
+++ b/pkger-core/Cargo.toml
@@ -39,5 +39,8 @@ lazy_static = "1"
 git2 = "0.14"
 tokio = "1"
 
+http = "0.2"
+ipnet = "2"
+
 [dev-dependencies]
 pretty_assertions = "0.3"

--- a/pkger-core/src/build/mod.rs
+++ b/pkger-core/src/build/mod.rs
@@ -11,6 +11,7 @@ use crate::container::ExecOpts;
 use crate::gpg::GpgKey;
 use crate::image::{Image, ImageState, ImagesState};
 use crate::log::{debug, info, trace, warning, write_out, BoxedCollector};
+use crate::proxy::ProxyConfig;
 use crate::recipe::{ImageTarget, Recipe, RecipeTarget};
 use crate::runtime::RuntimeConnector;
 use crate::ssh::SshConfig;
@@ -40,6 +41,7 @@ pub struct Context {
     simple: bool,
     gpg_key: Option<GpgKey>,
     ssh: Option<SshConfig>,
+    proxy: ProxyConfig,
 }
 
 impl Context {
@@ -55,6 +57,7 @@ impl Context {
         simple: bool,
         gpg_key: Option<GpgKey>,
         ssh: Option<SshConfig>,
+        proxy: ProxyConfig,
     ) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -92,6 +95,7 @@ impl Context {
             simple,
             gpg_key,
             ssh,
+            proxy,
         }
     }
 

--- a/pkger-core/src/lib.rs
+++ b/pkger-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod image;
 #[macro_export]
 pub mod log;
 pub mod oneshot;
+pub mod proxy;
 pub mod recipe;
 pub mod runtime;
 pub mod ssh;

--- a/pkger-core/src/proxy.rs
+++ b/pkger-core/src/proxy.rs
@@ -32,7 +32,7 @@ impl FromStr for NoProxyOption {
         if let Ok(addr) = s.parse::<IpAddr>() {
             return Ok(Self::IpAddr(addr));
         }
-        if s.starts_with(".") || s.starts_with("*") {
+        if s.starts_with('.') || s.starts_with('*') {
             return Ok(Self::WildcardDomain(s.into()));
         }
 
@@ -142,22 +142,20 @@ impl ProxyConfig {
         let is_ip = res.is_ok();
         let addr = if is_ip {
             Some(res.unwrap())
-        } else {
-            if let Some(addr) = host
-                .to_socket_addrs()
-                .ok()
-                .and_then(|mut addrs| addrs.next())
-            {
-                match addr.port() {
-                    443 if self.https_proxy.is_some() => should_proxy = ShouldProxyResult::Https,
-                    80 if self.http_proxy.is_some() => should_proxy = ShouldProxyResult::Http,
-                    _ => {}
-                }
-
-                Some(addr.ip())
-            } else {
-                None
+        } else if let Some(addr) = host
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut addrs| addrs.next())
+        {
+            match addr.port() {
+                443 if self.https_proxy.is_some() => should_proxy = ShouldProxyResult::Https,
+                80 if self.http_proxy.is_some() => should_proxy = ShouldProxyResult::Http,
+                _ => {}
             }
+
+            Some(addr.ip())
+        } else {
+            None
         };
 
         for opt in &self.no_proxy {

--- a/pkger-core/src/proxy.rs
+++ b/pkger-core/src/proxy.rs
@@ -166,11 +166,13 @@ impl ProxyConfig {
                     NoProxyOption::Ipv4Net(net) => {
                         if net.contains(&addr) {
                             should_proxy = ShouldProxyResult::No;
+                            break;
                         }
                     }
                     NoProxyOption::IpAddr(IpAddr::V4(noproxy_addr)) => {
                         if noproxy_addr == &addr {
                             should_proxy = ShouldProxyResult::No;
+                            break;
                         }
                     }
                     _ => {}
@@ -179,11 +181,13 @@ impl ProxyConfig {
                     NoProxyOption::Ipv6Net(net) => {
                         if net.contains(&addr) {
                             should_proxy = ShouldProxyResult::No;
+                            break;
                         }
                     }
                     NoProxyOption::IpAddr(IpAddr::V6(noproxy_addr)) => {
                         if noproxy_addr == &addr {
                             should_proxy = ShouldProxyResult::No;
+                            break;
                         }
                     }
                     _ => {}
@@ -195,12 +199,14 @@ impl ProxyConfig {
                 NoProxyOption::Domain(domain) if !is_ip => {
                     if domain == host {
                         should_proxy = ShouldProxyResult::No;
+                        break;
                     }
                 }
                 NoProxyOption::WildcardDomain(domain) if !is_ip => {
                     let domain = domain.trim_start_matches('*').trim_start_matches('.');
                     if host.contains(domain) {
                         should_proxy = ShouldProxyResult::No;
+                        break;
                     }
                 }
                 _ => {}

--- a/pkger-core/src/proxy.rs
+++ b/pkger-core/src/proxy.rs
@@ -1,0 +1,265 @@
+use http::Uri;
+use std::{env, str::FromStr};
+use std::net::{self, ToSocketAddrs, IpAddr};
+use ipnet::{Ipv6Net, Ipv4Net};
+
+pub const HTTPS_PROXY_ENV: &str = "https_proxy";
+pub const HTTP_PROXY_ENV: &str = "http_proxy";
+pub const NO_PROXY_ENV: &str = "no_proxy";
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum NoProxyOption {
+    IpAddr(IpAddr),
+    Ipv4Net(Ipv4Net),
+    Ipv6Net(Ipv6Net),
+    Domain(String),
+    WildcardDomain(String),
+}
+
+impl FromStr for NoProxyOption {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(anyhow!("Invalid address"));
+        }
+        if let Ok(addr) = s.parse::<Ipv4Net>() {
+            return Ok(Self::Ipv4Net(addr));
+        }
+        if let Ok(addr) = s.parse::<Ipv6Net>() {
+            return Ok(Self::Ipv6Net(addr));
+        }
+        if let Ok(addr) = s.parse::<IpAddr>() {
+            return Ok(Self::IpAddr(addr));
+        }
+        if s.starts_with(".") || s.starts_with("*") {
+            return Ok(Self::WildcardDomain(s.into()));
+        }
+
+        if !s.contains('.') {
+            return Err(anyhow!("Invalid address"));
+        }
+        
+        Ok(Self::Domain(s.into()))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ShouldProxyResult {
+    Http,
+    Https,
+    No
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct ProxyConfig {
+    https_proxy: Option<Uri>,
+    http_proxy: Option<Uri>,
+    no_proxy: Vec<NoProxyOption>,
+}
+
+impl ProxyConfig {
+    pub fn from_env() -> Self {
+        let https_proxy = env::var(HTTPS_PROXY_ENV)
+            .ok()
+            .or_else(|| env::var(HTTPS_PROXY_ENV.to_ascii_uppercase()).ok());
+        let http_proxy = env::var(HTTP_PROXY_ENV)
+            .ok()
+            .or_else(|| env::var(HTTP_PROXY_ENV.to_ascii_uppercase()).ok());
+        let mut no_proxy = vec![];
+        for addr in env::var(NO_PROXY_ENV)
+            .ok()
+            .or_else(|| env::var(NO_PROXY_ENV.to_ascii_uppercase()).ok())
+            .unwrap_or_default().split(',') {
+                if let Ok(addr) = addr.parse::<NoProxyOption>() {
+                    no_proxy.push(addr);
+                }
+        }
+
+        ProxyConfig {
+            https_proxy: https_proxy.and_then(|addr| addr.parse().ok()),
+            http_proxy: http_proxy.and_then(|addr| addr.parse().ok()),
+            no_proxy,
+        }
+    }
+
+    pub fn set_https_proxy(&mut self, uri: Uri) {
+        self.https_proxy = Some(uri);
+    }
+
+    pub fn set_http_proxy(&mut self, uri: Uri) {
+        self.http_proxy = Some(uri);
+    }
+
+    pub fn set_no_proxy(&mut self, no_proxy: impl IntoIterator<Item = NoProxyOption>) {
+        self.no_proxy = no_proxy.into_iter().collect();
+    }
+
+    pub fn http_proxy(&self) -> Option<&Uri> {
+        self.http_proxy.as_ref()
+    }
+
+    pub fn https_proxy(&self) -> Option<&Uri> {
+        self.https_proxy.as_ref()
+    }
+
+    pub fn no_proxy(&self) -> &[NoProxyOption] {
+        &self.no_proxy[..]
+    }
+
+    pub fn is_proxy_set(&self) -> bool {
+        self.http_proxy.is_some() || self.https_proxy.is_some()
+    }
+
+    pub fn should_proxy(&self, uri: impl TryInto<Uri>) -> ShouldProxyResult {
+        let uri = if let Ok(uri) = uri.try_into() { 
+            uri
+        } else {
+            return ShouldProxyResult::No;
+        };
+        let mut should_proxy = ShouldProxyResult::No;
+
+        match uri.scheme_str() {
+            Some("https") if self.https_proxy.is_some() => should_proxy = ShouldProxyResult::Https,
+            Some("http") if self.http_proxy.is_some() => should_proxy = ShouldProxyResult::Http,
+            _ => {}
+        }
+
+        match uri.port_u16() {
+            Some(443) if self.https_proxy.is_some() => should_proxy = ShouldProxyResult::Https,
+            Some(80) if self.http_proxy.is_some() => should_proxy = ShouldProxyResult::Http,
+            _ => {}
+        }
+
+        let host = match uri.host() {
+            Some(host) => host,
+            None => return ShouldProxyResult::No,
+        };
+
+        let res = host.parse::<net::IpAddr>();
+        let is_ip = res.is_ok();
+        let addr = if is_ip { Some(res.unwrap()) } else { 
+            if let Some(addr) = host.to_socket_addrs().ok().and_then(|mut addrs| addrs.next()) {
+                match addr.port() {
+                    443 if self.https_proxy.is_some() => should_proxy = ShouldProxyResult::Https,
+                    80 if self.http_proxy.is_some() => should_proxy = ShouldProxyResult::Http,
+                    _ => {}
+                }
+
+                Some(addr.ip())
+            } else {
+                None
+            }
+        };
+
+        for opt in &self.no_proxy {
+            match addr {
+                Some(IpAddr::V4(addr)) => {
+                    match opt {
+                        NoProxyOption::Ipv4Net(net) => {
+                            if net.contains(&addr) {
+                                should_proxy = ShouldProxyResult::No;
+                            }
+                        },
+                        NoProxyOption::IpAddr(IpAddr::V4(noproxy_addr)) => {
+                            if noproxy_addr == &addr {
+                                should_proxy = ShouldProxyResult::No;
+                            }
+                        }
+                        _ => {}
+                    }
+                },
+                Some(IpAddr::V6(addr)) => {
+                    match opt {
+                        NoProxyOption::Ipv6Net(net) => {
+                            if net.contains(&addr) {
+                                should_proxy = ShouldProxyResult::No;
+                            }
+                        },
+                        NoProxyOption::IpAddr(IpAddr::V6(noproxy_addr)) => {
+                            if noproxy_addr == &addr {
+                                should_proxy = ShouldProxyResult::No;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+
+            match opt {
+                NoProxyOption::Domain(domain) if !is_ip => {
+                    if domain == host {
+                        should_proxy = ShouldProxyResult::No;
+                    }
+                }
+                NoProxyOption::WildcardDomain(domain) if !is_ip => {
+                    let domain = domain.trim_start_matches('*').trim_start_matches('.');
+                    if host.contains(domain) {
+                        should_proxy = ShouldProxyResult::No;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+
+        should_proxy
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn parses_proxy_from_env() {
+        env::set_var(HTTPS_PROXY_ENV, "http://proxy.test.com:80");
+        env::set_var(NO_PROXY_ENV, "10.0.0.0/8,.test.com");
+
+        let config = ProxyConfig::from_env();
+        assert_eq!(config.http_proxy(), None);
+        assert_eq!(config.https_proxy(), Some(&"http://proxy.test.com:80".parse().unwrap()));
+        assert_eq!(config.no_proxy(), &[
+            NoProxyOption::Ipv4Net("10.0.0.0/8".parse().unwrap()),
+            NoProxyOption::WildcardDomain(".test.com".into()),
+        ]);
+
+
+        env::remove_var(HTTPS_PROXY_ENV);
+        env::remove_var(NO_PROXY_ENV);
+        env::set_var(HTTPS_PROXY_ENV.to_lowercase(), "http://proxy.test.com:80");
+        env::set_var(HTTP_PROXY_ENV.to_lowercase(), "http://proxy.test.com:80");
+        env::set_var(NO_PROXY_ENV.to_lowercase(), "10.0.0.1,*.test.com,test.com");
+
+        let config = ProxyConfig::from_env();
+        assert_eq!(config.https_proxy(), Some(&"http://proxy.test.com:80".parse().unwrap()));
+        assert_eq!(config.https_proxy(), Some(&"http://proxy.test.com:80".parse().unwrap()));
+        assert_eq!(config.no_proxy(), &[
+            NoProxyOption::IpAddr("10.0.0.1".parse().unwrap()),
+            NoProxyOption::WildcardDomain("*.test.com".into()),
+            NoProxyOption::Domain("test.com".into()),
+        ]);
+    }
+
+    #[test]
+    fn should_proxy() {
+        env::set_var(HTTPS_PROXY_ENV, "http://proxy.test.com:80");
+        env::set_var(NO_PROXY_ENV, "10.0.0.0/8,.test.com");
+        let config = ProxyConfig::from_env();
+
+        assert_eq!(ShouldProxyResult::No, config.should_proxy("10.0.0.1:443"));
+        assert_eq!(ShouldProxyResult::Https, config.should_proxy("16.9.9.1:443"));
+        assert_eq!(ShouldProxyResult::Https, config.should_proxy("https://16.9.9.1/test"));
+        assert_eq!(ShouldProxyResult::No, config.should_proxy("16.9.9.1:80"));
+        assert_eq!(ShouldProxyResult::No, config.should_proxy("http://16.9.9.1"));
+        assert_eq!(ShouldProxyResult::No, config.should_proxy("https://test.com"));
+        assert_eq!(ShouldProxyResult::No, config.should_proxy("https://some.test.com"));
+        assert_eq!(ShouldProxyResult::No, config.should_proxy("https://some.more.test.com"));
+        assert_eq!(ShouldProxyResult::Https, config.should_proxy("https://other.com"));
+        assert_eq!(ShouldProxyResult::Https, config.should_proxy("https://some.other.com"));
+        assert_eq!(ShouldProxyResult::Https, config.should_proxy("https://some.more.other.com"));
+    }
+}

--- a/pkger-core/src/proxy.rs
+++ b/pkger-core/src/proxy.rs
@@ -249,9 +249,18 @@ mod test {
 
         env::remove_var(HTTPS_PROXY_ENV);
         env::remove_var(NO_PROXY_ENV);
-        env::set_var(HTTPS_PROXY_ENV.to_ascii_uppercase(), "http://proxy.test.com:80");
-        env::set_var(HTTP_PROXY_ENV.to_ascii_uppercase(), "http://proxy.test.com:80");
-        env::set_var(NO_PROXY_ENV.to_ascii_uppercase(), "10.0.0.1,*.test.com,test.com");
+        env::set_var(
+            HTTPS_PROXY_ENV.to_ascii_uppercase(),
+            "http://proxy.test.com:80",
+        );
+        env::set_var(
+            HTTP_PROXY_ENV.to_ascii_uppercase(),
+            "http://proxy.test.com:80",
+        );
+        env::set_var(
+            NO_PROXY_ENV.to_ascii_uppercase(),
+            "10.0.0.1,*.test.com,test.com",
+        );
 
         let config = ProxyConfig::from_env();
         assert_eq!(
@@ -280,7 +289,10 @@ mod test {
         env::remove_var(HTTPS_PROXY_ENV.to_ascii_uppercase());
         env::remove_var(HTTP_PROXY_ENV.to_ascii_uppercase());
         env::remove_var(NO_PROXY_ENV.to_ascii_uppercase());
-        env::set_var(HTTPS_PROXY_ENV.to_ascii_uppercase(), "http://proxy.test.com:80");
+        env::set_var(
+            HTTPS_PROXY_ENV.to_ascii_uppercase(),
+            "http://proxy.test.com:80",
+        );
         env::set_var(NO_PROXY_ENV.to_ascii_uppercase(), "10.0.0.0/8,.test.com");
         let config = ProxyConfig::from_env();
 
@@ -323,7 +335,10 @@ mod test {
             config.should_proxy("https://some.more.other.com")
         );
 
-        env::set_var(HTTP_PROXY_ENV.to_ascii_uppercase(), "http://proxy.test.com:80");
+        env::set_var(
+            HTTP_PROXY_ENV.to_ascii_uppercase(),
+            "http://proxy.test.com:80",
+        );
         env::set_var(NO_PROXY_ENV.to_ascii_uppercase(), "*.some.test.com");
         let config = ProxyConfig::from_env();
         println!("{:?}", config);


### PR DESCRIPTION
This PR adds support for standard proxy environment variables like `http_proxy`, `https_proxy` and `no_proxy` when pulling a repository. In the future, proxy config will be respected in all http/https calls.