### PR TITLE
Fix patches and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.0
+- Change how patch failures are handled. Previously patch failures were ignored and could be easily overlooked, now a failure in applying/reading a patch results in termination of a job
+
 # 0.10.0
 - Add support for env variables in git source url
 - Fix builds using podman runtime

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test:
 	cargo t --all-targets --all-features -- --test-threads=1
 	cargo r -- -c example/conf.yml build test-package test-suite child-package1 child-package2
 	cargo r -- -c example/conf.yml build -s apk -s pkg -- test-package
+	cargo r -- -c example/conf.yml build -s rpm -- test-patches
+	# below should fail
+	-cargo r -- -c example/conf.yml build -s rpm -- test-fail-non-existent-patch
+	test $? 1
 
 
 .PHONY: fmt_check

--- a/example/recipes/test-fail-non-existent-patch/recipe.yml
+++ b/example/recipes/test-fail-non-existent-patch/recipe.yml
@@ -1,0 +1,11 @@
+---
+metadata:
+  name: test-fail-non-existent-patch
+  version: 0.1.0
+  description: This recipe should fail as it specifies a patch that doesn't exist
+  arch: x86_64
+  license: MIT
+  patches:
+    - dummy.patch
+build:
+  steps: []

--- a/example/recipes/test-patches/recipe.yml
+++ b/example/recipes/test-patches/recipe.yml
@@ -1,0 +1,22 @@
+---
+metadata:
+  name: test-patches
+  version: 0.1.0
+  description: pkger test package
+  arch: x86_64
+  license: MIT
+  source:
+    - src
+    - testrootfile
+  patches:
+    - patch: src.patch
+      strip: 1
+    - root.patch
+build:
+  steps:
+    - cmd: >-
+        if [[ $(cat src/testfile) =~ "exxample-patch321-patched" ]]; then exit 0; else
+        echo "Test file src/testfile has invalid content"; exit 1; fi
+    - cmd: >-
+        if [[ $(cat testrootfile) =~ "root-file-patched" ]]; then exit 0; else
+        echo "Test file testrootfile has invalid content"; exit 1; fi

--- a/example/recipes/test-patches/root.patch
+++ b/example/recipes/test-patches/root.patch
@@ -1,0 +1,5 @@
+--- testrootfile	2022-12-02 11:07:20.563951424 +0100
++++ testrootfile1	2022-12-02 11:11:45.062500002 +0100
+@@ -1 +1 @@
+-root-file-pre-patch
++root-file-patched

--- a/example/recipes/test-patches/src.patch
+++ b/example/recipes/test-patches/src.patch
@@ -1,0 +1,7 @@
+diff --git a/src/testfile b/src/testfile
+index f5a1474..f15fd5e 100644
+--- a/src/testfile
++++ b/src/testfile
+@@ -1 +1 @@
+-example-patch123
++exxample-patch321-patched

--- a/example/recipes/test-patches/src/testfile
+++ b/example/recipes/test-patches/src/testfile
@@ -1,0 +1,1 @@
+example-patch123

--- a/example/recipes/test-patches/testrootfile
+++ b/example/recipes/test-patches/testrootfile
@@ -1,0 +1,1 @@
+root-file-pre-patch

--- a/pkger-cli/src/app/mod.rs
+++ b/pkger-cli/src/app/mod.rs
@@ -358,7 +358,7 @@ impl Application {
     fn copy(&self, object: CopyObject) -> Result<()> {
         fn copy_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
             let dst = dst.as_ref();
-            fs::create_dir_all(&dst).context("creating destination directory failed")?;
+            fs::create_dir_all(dst).context("creating destination directory failed")?;
             for entry in fs::read_dir(src).context("reading source directory failed")? {
                 match entry {
                     Ok(entry) => {
@@ -672,7 +672,7 @@ impl Application {
         let mut images = vec![];
 
         if let Some(dir) = &self.config.images_dir {
-            let mut entries: Vec<_> = fs::read_dir(&dir)
+            let mut entries: Vec<_> = fs::read_dir(dir)
                 .context("failed to read images directory")?
                 .filter(|e| match e {
                     Ok(e) => {

--- a/pkger-core/src/build/image.rs
+++ b/pkger-core/src/build/image.rs
@@ -205,7 +205,7 @@ RUN {} {} && \
     match &ctx.build.runtime {
         RuntimeConnector::Docker(docker) => {
             let images = docker.images();
-            let opts = ImageBuildOpts::builder(&temp_path)
+            let opts = ImageBuildOpts::builder(temp_path)
                 .tag(format!("{}:{}", state.image, CACHED))
                 .build();
 
@@ -301,7 +301,7 @@ pub async fn find_cached_state(
 
     trace!("checking if image should be rebuilt");
     let states = state.read().await;
-    if let Some(state) = (*states).images.get(target) {
+    if let Some(state) = states.images.get(target) {
         if simple {
             return Some(state.to_owned());
         }

--- a/pkger-core/src/build/mod.rs
+++ b/pkger-core/src/build/mod.rs
@@ -190,6 +190,8 @@ pub async fn run(ctx: &mut Context, logger: &mut BoxedCollector) -> Result<PathB
     if let Some(patches) = &ctx.recipe.metadata.patches {
         let patches = patches::collect(&container_ctx, patches, logger).await?;
         patches::apply(&container_ctx, patches, logger).await?;
+    } else {
+        debug!(logger => "no patches to apply");
     }
 
     scripts::run(&container_ctx, logger).await?;

--- a/pkger-core/src/build/package/apk.rs
+++ b/pkger-core/src/build/package/apk.rs
@@ -125,7 +125,7 @@ impl Package for Apk {
             .as_ref()
             .and_then(|apk| apk.private_key.as_deref())
         {
-            if let Ok(key) = std::fs::read(&key_location) {
+            if let Ok(key) = std::fs::read(key_location) {
                 info!("uploading signing key");
                 trace!(logger => "key location: {}", key_location.display());
                 ctx.container

--- a/pkger-core/src/build/package/rpm.rs
+++ b/pkger-core/src/build/package/rpm.rs
@@ -43,9 +43,9 @@ impl Package for Rpm {
         let specs = base_path.join("SPECS");
         let sources = base_path.join("SOURCES");
         let rpms = base_path.join("RPMS");
-        let rpms_arch = rpms.join(&arch);
+        let rpms_arch = rpms.join(arch);
         let srpms = base_path.join("SRPMS");
-        let arch_dir = rpms.join(&arch);
+        let arch_dir = rpms.join(arch);
         let rpm_name = format!("{}.rpm", package_name);
         let tmp_buildroot = PathBuf::from(["/tmp/", &package_name].join(""));
         let source_tar_path = sources.join(&source_tar);

--- a/pkger-core/src/build/package/sign.rs
+++ b/pkger-core/src/build/package/sign.rs
@@ -18,7 +18,7 @@ pub(crate) async fn upload_gpg_key(
     logger: &mut BoxedCollector,
 ) -> Result<PathBuf> {
     info!(logger => "uploading GPG key to '{}'", destination.display());
-    let key = fs::read(&gpg_key.path()).context("failed reading the gpg key")?;
+    let key = fs::read(gpg_key.path()).context("failed reading the gpg key")?;
 
     ctx.container
         .upload_files(

--- a/pkger-core/src/build/patches.rs
+++ b/pkger-core/src/build/patches.rs
@@ -80,8 +80,7 @@ pub async fn collect(
 
     let to_copy = to_copy.iter().map(PathBuf::as_path).collect::<Vec<_>>();
 
-    let patches_archive = ctx.build.container_tmp_dir.join("patches.tar");
-    remote::fetch_fs_source(ctx, &to_copy, &patches_archive, logger).await?;
+    remote::fetch_fs_source(ctx, &to_copy, &patch_dir, logger).await?;
 
     Ok(out)
 }

--- a/pkger-core/src/build/patches.rs
+++ b/pkger-core/src/build/patches.rs
@@ -1,5 +1,5 @@
 use crate::build::{container, remote};
-use crate::log::{debug, info, trace, warning, BoxedCollector};
+use crate::log::{debug, info, trace, BoxedCollector};
 use crate::recipe::{Patch, Patches};
 use crate::runtime::container::ExecOpts;
 use crate::Result;
@@ -21,21 +21,17 @@ pub async fn apply(
             }
         }
         debug!(logger => "applying patch: {:?}", patch);
-        if let Err(e) = ctx
-            .checked_exec(
-                &ExecOpts::default()
-                    .cmd(&format!(
-                        "patch -p{} < {}",
-                        patch.strip_level(),
-                        location.display()
-                    ))
-                    .working_dir(&ctx.build.container_bld_dir),
-                logger,
-            )
-            .await
-        {
-            warning!(logger => "applying patch {:?} failed, reason = {:?}", patch, e);
-        }
+        ctx.checked_exec(
+            &ExecOpts::default()
+                .cmd(&format!(
+                    "patch -p{} < {}",
+                    patch.strip_level(),
+                    location.display()
+                ))
+                .working_dir(&ctx.build.container_bld_dir),
+            logger,
+        )
+        .await?;
     }
 
     Ok(())

--- a/pkger-core/src/build/remote.rs
+++ b/pkger-core/src/build/remote.rs
@@ -93,6 +93,9 @@ pub async fn fetch_fs_source(
     let mut tar = tar::Builder::new(tar_file);
 
     for path in files {
+        if !path.exists() {
+            return Err(anyhow!("source path '{}' doesn't exist", path.display()));
+        }
         if path.is_dir() {
             trace!(logger => "adding entry {} to archive", path.display());
             let dir_name = path.file_name().unwrap_or_default();

--- a/pkger-core/src/runtime/container.rs
+++ b/pkger-core/src/runtime/container.rs
@@ -1,6 +1,6 @@
 use crate::log::{trace, BoxedCollector};
 use crate::recipe::Env;
-use crate::Result;
+use anyhow::{anyhow, Result};
 
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
@@ -32,6 +32,16 @@ pub struct Output<T> {
     pub stdout: Vec<T>,
     pub stderr: Vec<T>,
     pub exit_code: u64,
+}
+
+impl Output<String> {
+    pub fn as_result(self) -> Result<Vec<String>> {
+        if self.exit_code != 0 {
+            Err(anyhow!(self.stderr.join("\n")))
+        } else {
+            Ok(self.stdout)
+        }
+    }
 }
 
 #[derive(Clone, Default, Debug)]

--- a/pkger-core/src/runtime/docker.rs
+++ b/pkger-core/src/runtime/docker.rs
@@ -213,7 +213,10 @@ impl Container for DockerContainer {
         let tar_path = self
             .upload_archive(tarball, destination, archive_name, logger)
             .await?;
-        trace!("extract archive with files");
+        trace!(
+            "extract archive '{archive_name} with files to {}",
+            destination.display()
+        );
 
         self.exec(
             &ExecOpts::default()
@@ -222,8 +225,9 @@ impl Container for DockerContainer {
             logger,
         )
         .await
+        .context("failed to extract archive with files to container")?
+        .as_result()
         .map(|_| ())
-        .context("failed to extract archive with files to container")
     }
 }
 

--- a/pkger-core/src/runtime/podman.rs
+++ b/pkger-core/src/runtime/podman.rs
@@ -231,8 +231,9 @@ impl Container for PodmanContainer {
             logger,
         )
         .await
+        .context("failed to extract archive with files to container")?
+        .as_result()
         .map(|_| ())
-        .context("failed to extract archive with files to container")
     }
 }
 


### PR DESCRIPTION
This PR adds early exits for when pkger fails to load a patch or fails to apply the patch. Previously the patch would be silently ignored if it failed. Other than that the directory where the patches were uploaded was incorrect and got fixed as well.

There are also tests included that should prevent future breakage from happening.


Closes: #90 