### PR TITLE
Fix dependencies resolution for custom images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           sudo dpkg -i example/output/debian/test-package-0.1.0-0.amd64.deb
           cat /test/deb/test_file
       - name: Install alien
-        run: sudo apt install alien
+        run: sudo apt install -y alien rpm
       - name: Verify RPM package
         run: |
           sudo alien -i example/output/rocky/test-package-0.1.0-0.x86_64.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
         uses: hecrj/setup-rust-action@v1
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install rpm
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt -y update
+          sudo apt -y install rpm
       - name: Test
         run: make test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.11.0
 - Change how patch failures are handled. Previously patch failures were ignored and could be easily overlooked, now a failure in applying/reading a patch results in termination of a job
 - Fix checks for default runtime socket
+- Fix dependencies resolution for custom images. As stated in the documentation, when there are dependencies specified for a simple image like `pkger-rpm` they should be shared with custom RPM based distros. Previously this was not the case.
 
 # 0.10.0
 - Add support for env variables in git source url

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ test:
 	# below should fail
 	-cargo r -- -c example/conf.yml build -s rpm -- test-fail-non-existent-patch
 	test $? 1
+	cargo r -- -c example/conf.yml build -i rocky debian -- test-common-dependencies
+	@rpm -qp --requires example/output/rocky/test-common-dependencies-0.1.0-0.x86_64.rpm | grep openssl-devel
+	@rpm -qp --conflicts example/output/rocky/test-common-dependencies-0.1.0-0.x86_64.rpm | grep httpd
+	@rpm -qp --obsoletes example/output/rocky/test-common-dependencies-0.1.0-0.x86_64.rpm | grep bison1
+	@dpkg-deb -I example/output/debian/test-common-dependencies-0.1.0-0.amd64.deb | grep Depends | grep libssl-dev
+	@dpkg-deb -I example/output/debian/test-common-dependencies-0.1.0-0.amd64.deb | grep Conflicts | grep apache2
 
 
 .PHONY: fmt_check

--- a/example/recipes/test-common-dependencies/recipe.yml
+++ b/example/recipes/test-common-dependencies/recipe.yml
@@ -1,0 +1,32 @@
+metadata:
+  name: test-common-dependencies
+  description: Test that dependencies for common images like `pkger-rpm` get shared to other RPM based distros
+  arch: x86_64
+  license: MIT
+  version: 0.1.0
+  all_images: true
+  build_depends:
+    pkger-rpm: [ bison ]
+    pkger-deb: [ bison ]
+  depends:
+    pkger-rpm: [ openssl-devel ]
+    pkger-deb: [ libssl-dev ]
+  conflicts:
+    pkger-rpm: [ httpd ]
+    pkger-deb: [ apache2 ]
+  rpm:
+    obsoletes:
+      pkger-rpm: [ bison1 ]
+build:
+  shell: /bin/bash
+  steps:
+    - cmd: |
+        bison --version
+        if [ $? -eq 0 ]; then exit 0; else echo \
+        'bison is not installed but should be part of the build_depends list'; exit 1; fi
+      images: [ rocky ]
+    - cmd: |
+        bison --version
+        if [ $? -eq 0 ]; then exit 0; else echo \
+        'bison is not installed but should be part of the build_depends list'; exit 1; fi
+      images: [ debian ]

--- a/pkger-core/src/build/image.rs
+++ b/pkger-core/src/build/image.rs
@@ -1,4 +1,4 @@
-use crate::build::{container, deps, Context};
+use crate::build::{container, Context};
 use crate::image::{ImageState, ImagesState};
 use crate::log::{debug, info, trace, warning, BoxedCollector};
 use crate::recipe::RecipeTarget;
@@ -20,16 +20,8 @@ pub static LATEST: &str = "latest";
 
 pub async fn build(ctx: &mut Context, logger: &mut BoxedCollector) -> Result<ImageState> {
     info!(logger => "building image '{}'", ctx.target.image());
-    let mut deps = if let Some(deps) = &ctx.recipe.metadata.build_depends {
-        deps.resolve_names(ctx.target.image())
-    } else {
-        Default::default()
-    };
-    deps.extend(deps::default(
-        ctx.target.build_target(),
-        &ctx.recipe,
-        ctx.gpg_key.is_some(),
-    ));
+
+    let deps = ctx.build_depends();
     trace!(logger => "resolved dependencies: {:?}", deps);
 
     let state = find_cached_state(

--- a/pkger-core/src/build/package/apk.rs
+++ b/pkger-core/src/build/package/apk.rs
@@ -76,6 +76,7 @@ impl Package for Apk {
                 &sources,
                 &bld_dir,
                 &ctx.build.build_version,
+                *ctx.build.target.build_target(),
                 logger,
             )
             .render()

--- a/pkger-core/src/build/package/deb.rs
+++ b/pkger-core/src/build/package/deb.rs
@@ -61,7 +61,13 @@ impl Package for Deb {
         let control = ctx
             .build
             .recipe
-            .as_deb_control(&image_state.image, size, &ctx.build.build_version, logger)
+            .as_deb_control(
+                &image_state.image,
+                size,
+                &ctx.build.build_version,
+                *ctx.build.target.build_target(),
+                logger,
+            )
             .render()
             .context("rendering apkbuild failed")?;
         debug!(logger => "{}", control);

--- a/pkger-core/src/build/package/pkg.rs
+++ b/pkger-core/src/build/package/pkg.rs
@@ -92,6 +92,7 @@ impl Package for Pkg {
                 &sources,
                 &checksums,
                 &ctx.build.build_version,
+                *ctx.build.target.build_target(),
                 logger,
             )
             .render()

--- a/pkger-core/src/build/package/rpm.rs
+++ b/pkger-core/src/build/package/rpm.rs
@@ -109,6 +109,7 @@ impl Package for Rpm {
                 &files[..],
                 &image_state.image,
                 &ctx.build.build_version,
+                *ctx.build.target.build_target(),
                 logger,
             )
             .render()


### PR DESCRIPTION
This PR fixes the case where dependencies for simple images like `pkger-rpm` would not be passed to custom RPM based images.

#92 