### PR TITLE
Add OpenSUSE support

### DIFF
--- a/pkger-core/src/build/package/rpm.rs
+++ b/pkger-core/src/build/package/rpm.rs
@@ -3,7 +3,7 @@ use crate::build::package::sign::{import_gpg_key, upload_gpg_key};
 use crate::build::package::{Manifest, Package};
 use crate::image::ImageState;
 use crate::log::{debug, info, trace, BoxedCollector};
-use crate::recipe::BuildArch;
+use crate::recipe::{BuildArch, Distro};
 use crate::runtime::container::ExecOpts;
 use crate::{ErrContext, Result};
 
@@ -39,7 +39,11 @@ impl Package for Rpm {
 
         info!(logger => "building RPM package {}", package_name);
 
-        let base_path = PathBuf::from("/root/rpmbuild");
+        let base_path = match image_state.os.distribution() {
+            Distro::OpenSuse => "/usr/src/packages",
+            _ => "/root/rpmbuild",
+        };
+        let base_path = PathBuf::from(base_path);
         let specs = base_path.join("SPECS");
         let sources = base_path.join("SOURCES");
         let rpms = base_path.join("RPMS");

--- a/pkger-core/src/recipe/metadata/os.rs
+++ b/pkger-core/src/recipe/metadata/os.rs
@@ -34,6 +34,10 @@ impl Os {
         self.distribution.as_ref()
     }
 
+    pub fn distribution(&self) -> Distro {
+        self.distribution
+    }
+
     pub fn package_manager(&self) -> PackageManager {
         let version: u8 = self.version().parse().unwrap_or_default();
         match self.distribution {
@@ -41,6 +45,7 @@ impl Os {
             Distro::Debian | Distro::Ubuntu => PackageManager::Apt,
             Distro::Rocky | Distro::RedHat | Distro::CentOS if version >= 8 => PackageManager::Dnf,
             Distro::Fedora if version >= 22 => PackageManager::Dnf,
+            Distro::OpenSuse => PackageManager::Zypper,
             Distro::Rocky => PackageManager::Dnf,
             Distro::RedHat | Distro::CentOS | Distro::Fedora => PackageManager::Yum,
             Distro::Alpine => PackageManager::Apk,
@@ -63,6 +68,7 @@ pub enum Distro {
     Debian,
     Fedora,
     RedHat,
+    OpenSuse,
     Ubuntu,
     Rocky,
     Alpine,
@@ -78,6 +84,7 @@ impl AsRef<str> for Distro {
             Debian => "debian",
             Fedora => "fedora",
             RedHat => "redhat",
+            OpenSuse => "opensuse",
             Ubuntu => "ubuntu",
             Rocky => "rocky",
             Alpine => "alpine",
@@ -95,6 +102,7 @@ impl From<&str> for Distro {
             ("debian", Debian),
             ("fedora", Fedora),
             ("redhat", RedHat),
+            ("opensuse", OpenSuse),
             ("red hat", RedHat),
             ("ubuntu", Ubuntu),
             ("rocky", Rocky),
@@ -118,6 +126,7 @@ pub enum PackageManager {
     Dnf,
     Pacman,
     Yum,
+    Zypper,
     Apk,
     Unknown,
 }
@@ -129,6 +138,7 @@ impl AsRef<str> for PackageManager {
             Self::Dnf => "dnf",
             Self::Pacman => "pacman",
             Self::Yum => "yum",
+            Self::Zypper => "zypper",
             Self::Apk => "apk",
             Self::Unknown => "unkown",
         }
@@ -142,6 +152,7 @@ impl PackageManager {
             Self::Dnf => vec!["install", "-y"],
             Self::Pacman => vec!["-S", "--noconfirm"],
             Self::Yum => vec!["install", "-y"],
+            Self::Zypper => vec!["install", "-y"],
             Self::Apk => vec!["add"],
             Self::Unknown => vec![],
         }
@@ -151,6 +162,7 @@ impl PackageManager {
         match self {
             Self::Apt => vec!["update", "-y"],
             Self::Dnf | Self::Yum => vec!["clean", "metadata"],
+            Self::Zypper => vec!["clean"],
             Self::Pacman => vec!["-Sy", "--noconfirm"],
             Self::Apk => vec!["update"],
             Self::Unknown => vec![],
@@ -160,7 +172,7 @@ impl PackageManager {
     pub fn upgrade_packages_args(&self) -> Vec<&'static str> {
         match self {
             Self::Apt => vec!["dist-upgrade", "-y"],
-            Self::Dnf | Self::Yum => vec!["update", "-y"],
+            Self::Dnf | Self::Yum | Self::Zypper => vec!["update", "-y"],
             Self::Pacman => vec!["-Syu", "--noconfirm"],
             Self::Apk => vec!["upgrade"],
             Self::Unknown => vec![],
@@ -171,6 +183,7 @@ impl PackageManager {
         match self {
             Self::Apt => vec!["clean"],
             Self::Dnf | Self::Yum => vec!["clean", "metadata"],
+            Self::Zypper => vec!["clean"],
             Self::Pacman => vec!["-Sc"],
             Self::Apk => vec!["cache", "clean"],
             Self::Unknown => vec![],


### PR DESCRIPTION
This PR adds support for building OpenSUSE RPM files. The existing RPM functionality works fine on OpenSUSE, except it needs to build everything under a different path. Tested on [this recipe](https://github.com/ilya-zlobintsev/LACT/blob/master/pkg/recipes/lact/recipe.yml).